### PR TITLE
[codex] Add Phase 3 agent entrypoints and repair loop

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,80 @@
+name: Agent Task
+description: Structured implementation task that is eligible for bounded agent work
+title: "[Agent Task]: "
+labels:
+  - agent-ready
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Describe the implementation problem precisely enough for a branch-level agent to act.
+      placeholder: Explain the gap, bug, or improvement request.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List the exact outcomes that must be true before the work is considered done.
+      placeholder: |
+        - Output format stays deterministic.
+        - Existing fixtures still load.
+    validations:
+      required: true
+
+  - type: textarea
+    id: likely_paths
+    attributes:
+      label: Files likely affected
+      description: List the paths or areas you expect this task to touch.
+      placeholder: |
+        - src/blokus/cli.py
+        - tests/test_cli.py
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Required tests
+      description: State what tests must be added or updated for this issue.
+      placeholder: |
+        - Update CLI coverage in tests/test_cli.py.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ambiguity
+    attributes:
+      label: Rule ambiguity
+      description: Agents must stop when rule semantics are unclear.
+      options:
+        - no ambiguity
+        - possible ambiguity
+        - high ambiguity
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Areas affected
+      options:
+        - label: src/blokus
+        - label: tests
+        - label: fixtures
+        - label: schemas
+        - label: docs
+        - label: CLI
+        - label: .github / CI workflows
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Extra notes for the agent
+      description: Optional constraints, linked context, or review notes.
+      placeholder: Call out any reviewers, evidence, or non-obvious boundaries here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug Report
+description: Structured defect report for regressions, broken CLI flows, or CI-visible failures
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-human-spec
+body:
+  - type: textarea
+    id: broke
+    attributes:
+      label: What broke
+      description: Describe the observed bug or regression.
+      placeholder: The CLI exits 0 even when a move is invalid.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reproducible path.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+      placeholder: The command should exit nonzero and print a validation reason.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tests
+    attributes:
+      label: Required tests
+      description: What test coverage should be added or updated to prevent recurrence?
+      placeholder: Add a CLI regression test that asserts the failing exit code.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ambiguity
+    attributes:
+      label: Rule ambiguity
+      description: Bug reports with ambiguous rules should stay on the human-spec path.
+      options:
+        - no ambiguity
+        - possible ambiguity
+        - high ambiguity
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Areas affected
+      options:
+        - label: src/blokus
+        - label: tests
+        - label: fixtures
+        - label: schemas
+        - label: docs
+        - label: CLI
+        - label: .github / CI workflows

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/rule_ambiguity.yml
+++ b/.github/ISSUE_TEMPLATE/rule_ambiguity.yml
@@ -1,0 +1,47 @@
+name: Rule Ambiguity
+description: Human decision request for unclear rules or blocked semantics
+title: "[Rule Ambiguity]: "
+labels:
+  - rules
+  - needs-human-spec
+  - human-gate-required
+body:
+  - type: textarea
+    id: ambiguity
+    attributes:
+      label: Ambiguity or decision needed
+      description: Describe the unclear rule, semantic conflict, or competing interpretation.
+      placeholder: Explain the rule edge case that needs human confirmation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: blocked
+    attributes:
+      label: Why this blocks implementation
+      description: Explain why an agent or contributor cannot safely continue without a decision.
+      placeholder: The current requirements and fixtures imply different legality outcomes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: interpretations
+    attributes:
+      label: Candidate interpretations
+      description: List the plausible options if you already know them.
+      placeholder: |
+        - Interpretation A ...
+        - Interpretation B ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: likely_paths
+    attributes:
+      label: Files likely affected
+      description: List the paths that would change after the decision.
+      placeholder: |
+        - src/blokus/engine.py
+        - tests/test_engine.py
+    validations:
+      required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -65,3 +65,54 @@
 - name: in-progress
   color: "FBCA04"
   description: "Currently being worked on."
+
+- name: agent-ready
+  color: "0E8A16"
+  description: "Structured enough for bounded agent work."
+- name: agent-in-progress
+  color: "FBCA04"
+  description: "An agent branch or PR is actively being worked."
+- name: agent-blocked
+  color: "B60205"
+  description: "Autonomy stopped and needs human intervention."
+- name: needs-human-spec
+  color: "E99695"
+  description: "Task needs human clarification before agent work."
+- name: repair-loop
+  color: "5319E7"
+  description: "PR is inside the bounded repair loop."
+- name: needs-review
+  color: "C5DEF5"
+  description: "Human review checkpoint is required."
+
+- name: rules
+  color: "1D76DB"
+  description: "Game-rule or engine behavior scope."
+- name: cli
+  color: "0052CC"
+  description: "Command-line interface scope."
+- name: tests
+  color: "5319E7"
+  description: "Automated test coverage scope."
+- name: fixtures
+  color: "F9D0C4"
+  description: "Fixture or scenario input scope."
+- name: schemas
+  color: "FBCA04"
+  description: "Schema or contract scope."
+- name: docs
+  color: "0075CA"
+  description: "Documentation scope."
+- name: ci
+  color: "6F42C1"
+  description: "CI, workflow, or automation scope."
+
+- name: safe-autonomy
+  color: "0E8A16"
+  description: "Autonomy is allowed inside the branch loop."
+- name: workflow-sensitive
+  color: "B60205"
+  description: "Workflow or automation-sensitive paths changed."
+- name: human-gate-required
+  color: "D93F0B"
+  description: "Human gate required before autonomous progress."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,12 @@
 
 - [ ] Linked issue(s): <!-- e.g., #12 -->
 
+## Agent task mapping
+
+- [ ] Agent-ready label present if this is agent work
+- [ ] Scope widened during implementation: yes / no
+- [ ] Dedicated agent branch used if applicable
+
 ## Related requirement(s)
 
 - [ ] Requirement IDs listed (e.g., `R-F-04`, `R-T-04`)
@@ -17,12 +23,31 @@
 - [ ] Documentation changes
 - [ ] Schema/contract changes
 
+## Acceptance coverage
+
+- [ ] All acceptance criteria addressed
+- [ ] Tests updated
+- [ ] CLI behavior checked if relevant
+- [ ] Fixtures/schemas updated if relevant
+- [ ] Docs updated if relevant
+
 ## Validation
 
 - [ ] `./scripts/test.sh`
 - [ ] `./scripts/evaluate.sh` (if applicable)
 - [ ] CLI/manual checks (if applicable)
 - [ ] Other validation:
+
+## Ambiguity and assumptions
+
+<!-- Describe any assumptions the implementation made. If rule semantics were unclear, say so explicitly. -->
+
+## Risk review
+
+- [ ] No workflow files changed
+- [ ] No repository settings or secrets changes are implied
+- [ ] No protected-branch or environment boundary was crossed
+- [ ] Rule semantics changed: yes / no
 
 ## Human review needed
 

--- a/.github/workflows/agent-entry.yml
+++ b/.github/workflows/agent-entry.yml
@@ -1,0 +1,34 @@
+name: agent-entry
+
+on:
+  issues:
+    types:
+      - labeled
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to prepare for agent work
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  prepare:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'agent-ready'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build task packet
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          PYTHONPATH: src
+        run: python scripts/github/agent_entry.py

--- a/.github/workflows/failure-summary.yml
+++ b/.github/workflows/failure-summary.yml
@@ -1,0 +1,32 @@
+name: failure-summary
+
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  summarize:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Classify CI failure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          PYTHONPATH: src
+        run: python scripts/github/failure_summary.py

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,30 @@
+name: issue-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Route issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          PYTHONPATH: src
+        run: python scripts/github/issue_triage.py

--- a/.github/workflows/pr-intelligence.yml
+++ b/.github/workflows/pr-intelligence.yml
@@ -1,0 +1,30 @@
+name: pr-intelligence
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Post review intelligence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          PYTHONPATH: src
+        run: python scripts/github/pr_intelligence.py

--- a/.github/workflows/repair-loop.yml
+++ b/.github/workflows/repair-loop.yml
@@ -1,0 +1,47 @@
+name: repair-loop
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: Pull request number to repair
+        required: true
+        type: string
+      head_branch:
+        description: Agent branch to update
+        required: true
+        type: string
+      ci_run_id:
+        description: Source CI workflow run id
+        required: true
+        type: string
+      failure_category:
+        description: Classified CI failure category
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.head_branch }}
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run bounded repair
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          PYTHONPATH: src
+        run: python scripts/github/repair_loop.py

--- a/.github/workflows/seed-issues-labels.yml
+++ b/.github/workflows/seed-issues-labels.yml
@@ -44,6 +44,22 @@ jobs:
               { name: "needs-human-review", color: "E99695", description: "Cannot close without explicit human review." },
               { name: "ready", color: "0E8A16", description: "Ready to start." },
               { name: "in-progress", color: "FBCA04", description: "Currently being worked on." },
+              { name: "agent-ready", color: "0E8A16", description: "Structured enough for bounded agent work." },
+              { name: "agent-in-progress", color: "FBCA04", description: "An agent branch or PR is actively being worked." },
+              { name: "agent-blocked", color: "B60205", description: "Autonomy stopped and needs human intervention." },
+              { name: "needs-human-spec", color: "E99695", description: "Task needs human clarification before agent work." },
+              { name: "repair-loop", color: "5319E7", description: "PR is inside the bounded repair loop." },
+              { name: "needs-review", color: "C5DEF5", description: "Human review checkpoint is required." },
+              { name: "rules", color: "1D76DB", description: "Game-rule or engine behavior scope." },
+              { name: "cli", color: "0052CC", description: "Command-line interface scope." },
+              { name: "tests", color: "5319E7", description: "Automated test coverage scope." },
+              { name: "fixtures", color: "F9D0C4", description: "Fixture or scenario input scope." },
+              { name: "schemas", color: "FBCA04", description: "Schema or contract scope." },
+              { name: "docs", color: "0075CA", description: "Documentation scope." },
+              { name: "ci", color: "6F42C1", description: "CI, workflow, or automation scope." },
+              { name: "safe-autonomy", color: "0E8A16", description: "Autonomy is allowed inside the branch loop." },
+              { name: "workflow-sensitive", color: "B60205", description: "Workflow or automation-sensitive paths changed." },
+              { name: "human-gate-required", color: "D93F0B", description: "Human gate required before autonomous progress." },
             ];
 
             const issues = [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blocus Focus Pokus
 
-Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 should extend the same engine to Duo through mode configuration.
+Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 extends the same engine to Duo through mode configuration. Phase 3 adds structured issue intake, PR intelligence, and bounded branch-level agent repair.
 
 ## Project purpose
 
@@ -13,6 +13,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 
 - Phase 1 baseline: Classic mode, 4 players, JSON state I/O, legality checks, move application, legal-move generation, simple computer player, tests, and fixtures.
 - Phase 2 direction: Duo mode by configuration in the same engine (`ModeConfig` extension + tests/fixtures), not by a separate engine.
+- Phase 3 direction: structured issue forms, label-driven agent entry, PR review intelligence, and bounded autonomous repair on `agent/*` branches.
 
 ## Repository structure
 
@@ -24,6 +25,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - `docs/`: requirements, architecture, contracts, review discipline, traceability, issue seeds, evidence, and AI usage logs.
 - `.github/workflows/ci.yml`: CI lint + test + CLI smoke + fixture/schema + evaluation pipeline.
 - `.github/pull_request_template.md`: merge checklist with requirements/evidence/review gates.
+- `.github/ISSUE_TEMPLATE/`: structured issue intake for agent tasks, bugs, and rule ambiguity.
 - `.github/CODEOWNERS`: review routing for owned paths and governance checks.
 - `.github/labels.yml`: normalized label definitions for issue workflow.
 
@@ -35,6 +37,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - Ownership: `OWNERSHIP.md`.
 - Team/report snapshot: `TEAM_SUMMARY.md`.
 - Phase 1 governance setup: `docs/phase1-governance.md`.
+- Phase 3 policy and autonomy boundary: `docs/AGENT_POLICY.md`.
 - Evidence: `docs/evidence-log.md`.
 - AI usage disclosure: `docs/ai-usage.md`.
 

--- a/docs/AGENT_POLICY.md
+++ b/docs/AGENT_POLICY.md
@@ -1,0 +1,123 @@
+# Agent Policy
+
+## Purpose
+
+This document defines the Phase 3 trust boundary for repository automation. Agents may prepare, implement, and repair changes inside their own branch and pull request loop, but they do not replace protected-branch review, protected environments, or human approval.
+
+## What Counts As Agent-Ready
+
+An issue is agent-ready only when all of the following are true:
+
+- the issue uses the structured agent or bug form
+- the problem statement is specific
+- acceptance criteria are explicit
+- required tests are named
+- rule ambiguity is marked `no ambiguity`
+- the work does not require repository settings, secrets, or protected-environment authority
+
+If those conditions are not met, the issue must be routed to `needs-human-spec`.
+
+## Allowed Autonomous Actions
+
+For agent-ready tasks, the agent may:
+
+- create or update a dedicated `agent/*` branch
+- modify code, tests, fixtures, schemas, and docs related to the issue
+- open or update a pull request
+- summarize CI failures on its own branch
+- perform bounded repair on its own branch within the retry budget
+
+## Prohibited Autonomous Actions
+
+The agent may not:
+
+- merge to `main`
+- approve protected environments
+- change branch protections, secrets, repository settings, or environment configuration
+- invent game-rule semantics when requirements are ambiguous
+- widen scope beyond the linked issue without escalation
+- autonomously repair workflow-sensitive changes under `.github/`
+
+## Labels And Workflow States
+
+- `agent-ready`: structured enough for branch-level agent work
+- `agent-in-progress`: an agent branch or PR is actively being worked
+- `agent-blocked`: automation stopped and needs human intervention
+- `needs-human-spec`: requirements or ambiguity still need human clarification
+- `repair-loop`: the PR is inside the bounded autonomous repair loop
+- `needs-review`: a human review checkpoint is needed
+- `rules`, `cli`, `tests`, `fixtures`, `schemas`, `docs`, `ci`: impacted domain labels
+- `safe-autonomy`: autonomy is allowed inside the issue or PR branch loop
+- `workflow-sensitive`: `.github/` or automation-sensitive paths are involved
+- `human-gate-required`: agent work may draft changes, but humans must explicitly gate progress
+
+## Agent Task Contract
+
+Every agent-ready task uses the same contract:
+
+- keep changes scoped to the linked issue
+- explain assumptions in the pull request
+- update tests for behavior changes
+- stop and escalate if ambiguity is detected
+- stay inside the branch and pull-request path
+
+## Sensitive Files
+
+The following areas are treated as sensitive for autonomous repair:
+
+- `.github/`
+- `OWNERSHIP.md`
+- `TEAM_SUMMARY.md`
+- `docs/AGENT_POLICY.md`
+
+Agents may help draft changes in these areas when humans ask for them, but the bounded repair loop does not patch them automatically.
+
+## Repair Policy
+
+Autonomous repair is allowed only when all of the following are true:
+
+- the branch name starts with `agent/`
+- the pull request is not labeled `workflow-sensitive`
+- the pull request is not labeled `needs-human-spec`
+- the pull request is not labeled `human-gate-required`
+- the failure category is one of `lint`, `unit-test`, `cli-smoke`, or `fixture-schema`
+- the retry budget is not exhausted
+
+Retry budget:
+
+- maximum retries: `2`
+- after retry `2`, automation must stop and escalate
+
+Current bounded actions:
+
+- `lint`: attempt a deterministic `ruff --fix` patch, then push back to the same branch if changes were produced
+- `unit-test`, `cli-smoke`, `fixture-schema`: rerun failed CI jobs inside the retry budget
+- `evaluate`, `environment`, and `unknown`: escalate immediately
+
+## Escalation Policy
+
+Autonomy must stop and route back to humans when any of the following are true:
+
+- `needs-human-spec` is present
+- retry budget is exhausted
+- failure category is `unknown`
+- failure category is `evaluate`
+- workflow-sensitive files changed
+- the issue or PR widens scope beyond the linked task
+- the agent needs settings, permissions, or secret changes to proceed
+
+When escalation happens, workflows should:
+
+- add `agent-blocked`
+- add `needs-review`
+- remove or avoid `repair-loop`
+- post a comment that explains why autonomy stopped
+
+## Human Approval Boundaries
+
+Humans still approve:
+
+- all merges to `main`
+- changes that cross workflow or repository-governance boundaries
+- protected-environment approvals for `rc` and `submission`
+- any rule interpretation not already made explicit in the requirements or issue

--- a/scripts/github/agent_entry.py
+++ b/scripts/github/agent_entry.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Prepare a structured agent task packet for one issue."""
+
+from __future__ import annotations
+
+import os
+
+from blokus.automation import (
+    COMMENT_MARKERS,
+    build_agent_branch_name,
+    parse_markdown_sections,
+    section_value,
+)
+
+from gh_helpers import GitHubClient, load_event_payload
+
+
+def _issue_number_from_payload(payload: dict[str, object]) -> int:
+    if "issue" in payload:
+        return int(payload["issue"]["number"])
+    return int(payload["inputs"]["issue_number"])
+
+
+def main() -> int:
+    payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
+    issue_number = _issue_number_from_payload(payload)
+    client = GitHubClient(os.environ["GITHUB_REPOSITORY"], os.environ["GITHUB_TOKEN"])
+    issue = client.get_issue(issue_number)
+
+    labels = [label["name"] for label in issue["labels"]]
+    if "agent-ready" not in labels or "needs-human-spec" in labels:
+        body = "\n".join(
+            [
+                f"<!-- {COMMENT_MARKERS['entry']} -->",
+                "## Agent Task Packet",
+                "This issue is not currently eligible for agent entry.",
+                "",
+                "- `agent-ready` must be present.",
+                "- `needs-human-spec` must be absent.",
+            ]
+        )
+        client.upsert_issue_comment(issue_number, COMMENT_MARKERS["entry"], body)
+        return 0
+
+    sections = parse_markdown_sections(issue.get("body") or "")
+    branch_name = build_agent_branch_name(issue_number, issue["title"])
+
+    body_lines = [
+        f"<!-- {COMMENT_MARKERS['entry']} -->",
+        "## Agent Task Packet",
+        f"- Issue: #{issue_number}",
+        f"- Suggested branch: `{branch_name}`",
+        f"- Labels: {', '.join(f'`{label}`' for label in labels)}",
+        "",
+        "### Problem statement",
+        section_value(sections, "problem statement") or "Not provided.",
+        "",
+        "### Acceptance criteria",
+        section_value(sections, "acceptance criteria") or "Not provided.",
+        "",
+        "### Required tests",
+        section_value(sections, "required tests") or "Not provided.",
+        "",
+        "### Likely paths",
+        section_value(sections, "files likely affected") or "Not provided.",
+        "",
+        "### Guardrails",
+        "- Stay on the dedicated `agent/*` branch for this issue.",
+        "- Update tests for any changed behavior.",
+        "- Stop and escalate if rule semantics become ambiguous.",
+        "- Do not change repository settings, secrets, branch protections, or protected environments.",
+    ]
+
+    if "workflow-sensitive" in labels:
+        body_lines.extend(
+            [
+                "",
+                "### Human Gate",
+                "This issue touches workflow-sensitive areas. Agent work may draft changes, but autonomous repair remains disabled.",
+            ]
+        )
+
+    body_lines.extend(
+        [
+            "",
+            "### GitHub-native handoff",
+            "Assign this issue to GitHub Copilot coding agent from the issue sidebar when you want GitHub-hosted implementation to start.",
+        ]
+    )
+
+    client.upsert_issue_comment(issue_number, COMMENT_MARKERS["entry"], "\n".join(body_lines))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/failure_summary.py
+++ b/scripts/github/failure_summary.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Summarize CI failures and dispatch bounded repair when allowed."""
+
+from __future__ import annotations
+
+import os
+
+from blokus.automation import (
+    COMMENT_MARKERS,
+    REPAIR_STATE_MARKER,
+    classify_failure_category,
+    parse_state_marker,
+    render_state_marker,
+    repair_allowed,
+)
+
+from gh_helpers import GitHubClient, load_event_payload
+
+
+def main() -> int:
+    payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
+    workflow_run = payload["workflow_run"]
+    pull_requests = workflow_run.get("pull_requests") or []
+    if not pull_requests:
+        return 0
+
+    pull_number = int(pull_requests[0]["number"])
+    branch_name = workflow_run["head_branch"]
+    run_id = int(workflow_run["id"])
+    client = GitHubClient(os.environ["GITHUB_REPOSITORY"], os.environ["GITHUB_TOKEN"])
+
+    jobs = client.list_workflow_run_jobs(run_id)
+    failed_jobs = [
+        job["name"]
+        for job in jobs
+        if job.get("conclusion") in {"failure", "cancelled", "timed_out", "startup_failure"}
+    ]
+    category = classify_failure_category(failed_jobs)
+
+    pull_request = client.get_pull_request(pull_number)
+    labels = [label["name"] for label in pull_request["labels"]]
+    changed_files = [item["filename"] for item in client.list_pr_files(pull_number)]
+
+    repair_comments = client.list_issue_comments(pull_number)
+    repair_state = {"attempts": 0, "handled_runs": []}
+    for comment in reversed(repair_comments):
+        parsed = parse_state_marker(REPAIR_STATE_MARKER, comment.get("body", ""))
+        if parsed is not None:
+            repair_state = parsed
+            break
+
+    allowed, reason = repair_allowed(
+        branch_name=branch_name,
+        labels=labels,
+        category=category,
+        changed_files=changed_files,
+        retry_count=int(repair_state.get("attempts", 0)),
+    )
+
+    body_lines = [
+        f"<!-- {COMMENT_MARKERS['failure_summary']} -->",
+        "## CI Failure Summary",
+        f"- Source workflow: `{workflow_run['name']}`",
+        f"- Source run: `{run_id}`",
+        f"- Branch: `{branch_name}`",
+        f"- Failed jobs: {', '.join(f'`{name}`' for name in failed_jobs) or '`none detected`'}",
+        f"- Failure category: `{category}`",
+        f"- Autonomous repair eligible: `{'yes' if allowed else 'no'}`",
+        "",
+        "### Classification note",
+        reason,
+    ]
+    body_lines.append(render_state_marker("agent-failure-summary-state", {"category": category, "run_id": run_id}))
+    client.upsert_issue_comment(
+        pull_number,
+        COMMENT_MARKERS["failure_summary"],
+        "\n".join(body_lines),
+    )
+
+    if allowed:
+        client.add_labels(pull_number, ["repair-loop"])
+        client.dispatch_workflow(
+            "repair-loop.yml",
+            branch_name,
+            {
+                "pull_number": str(pull_number),
+                "head_branch": branch_name,
+                "ci_run_id": str(run_id),
+                "failure_category": category,
+            },
+        )
+    else:
+        client.remove_label(pull_number, "repair-loop")
+        if branch_name.startswith("agent/"):
+            client.add_labels(pull_number, ["agent-blocked", "needs-review"])
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/gh_helpers.py
+++ b/scripts/github/gh_helpers.py
@@ -1,0 +1,131 @@
+"""Minimal GitHub REST helpers for workflow scripts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+API_ROOT = "https://api.github.com"
+
+
+class GitHubClient:
+    """Tiny REST client for repository-local GitHub workflow automation."""
+
+    def __init__(self, repository: str, token: str) -> None:
+        self.repository = repository
+        self.token = token
+
+    def _request_url(self, method: str, url: str, payload: dict[str, Any] | None = None) -> tuple[Any, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = Request(url, data=body, method=method)
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("Authorization", f"Bearer {self.token}")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if body is not None:
+            request.add_header("Content-Type", "application/json")
+
+        with urlopen(request) as response:
+            text = response.read().decode("utf-8")
+            data = None if not text else json.loads(text)
+            return data, response.headers
+
+    def request(self, method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+        data, _ = self._request_url(method, f"{API_ROOT}{path}", payload)
+        return data
+
+    def paginate(self, path: str) -> list[Any]:
+        items: list[Any] = []
+        next_url = f"{API_ROOT}{path}"
+        while next_url:
+            data, headers = self._request_url("GET", next_url)
+            if isinstance(data, list):
+                items.extend(data)
+            elif data is not None:
+                items.append(data)
+            next_url = _next_link(headers.get("Link", ""))
+        return items
+
+    def get_issue(self, issue_number: int) -> dict[str, Any]:
+        return self.request("GET", f"/repos/{self.repository}/issues/{issue_number}")
+
+    def get_pull_request(self, pull_number: int) -> dict[str, Any]:
+        return self.request("GET", f"/repos/{self.repository}/pulls/{pull_number}")
+
+    def list_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        return self.paginate(f"/repos/{self.repository}/issues/{issue_number}/comments?per_page=100")
+
+    def list_pr_files(self, pull_number: int) -> list[dict[str, Any]]:
+        return self.paginate(f"/repos/{self.repository}/pulls/{pull_number}/files?per_page=100")
+
+    def list_workflow_run_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        jobs = self.paginate(f"/repos/{self.repository}/actions/runs/{run_id}/jobs?per_page=100")
+        return [job for item in jobs for job in item.get("jobs", [item]) if isinstance(item, dict)]
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        if not labels:
+            return
+        self.request(
+            "POST",
+            f"/repos/{self.repository}/issues/{issue_number}/labels",
+            {"labels": labels},
+        )
+
+    def remove_label(self, issue_number: int, label: str) -> None:
+        try:
+            self.request(
+                "DELETE",
+                f"/repos/{self.repository}/issues/{issue_number}/labels/{quote(label, safe='')}",
+            )
+        except HTTPError as exc:
+            if exc.code != 404:
+                raise
+
+    def upsert_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
+        existing = None
+        for comment in reversed(self.list_issue_comments(issue_number)):
+            if marker in comment.get("body", ""):
+                existing = comment
+                break
+
+        if existing is None:
+            self.request(
+                "POST",
+                f"/repos/{self.repository}/issues/{issue_number}/comments",
+                {"body": body},
+            )
+            return
+
+        self.request(
+            "PATCH",
+            f"/repos/{self.repository}/issues/comments/{existing['id']}",
+            {"body": body},
+        )
+
+    def dispatch_workflow(self, workflow_file: str, ref: str, inputs: dict[str, str]) -> None:
+        self.request(
+            "POST",
+            f"/repos/{self.repository}/actions/workflows/{quote(workflow_file, safe='')}/dispatches",
+            {"ref": ref, "inputs": inputs},
+        )
+
+    def rerun_failed_jobs(self, run_id: int) -> None:
+        self.request("POST", f"/repos/{self.repository}/actions/runs/{run_id}/rerun-failed-jobs")
+
+
+def load_event_payload(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _next_link(link_header: str) -> str | None:
+    for part in link_header.split(","):
+        pieces = [piece.strip() for piece in part.split(";")]
+        if len(pieces) < 2:
+            continue
+        if pieces[1] == 'rel="next"':
+            return pieces[0].strip("<>")
+    return None

--- a/scripts/github/issue_triage.py
+++ b/scripts/github/issue_triage.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Route structured issues into agent-ready or human-spec states."""
+
+from __future__ import annotations
+
+import os
+
+from blokus.automation import COMMENT_MARKERS, triage_issue
+
+from gh_helpers import GitHubClient, load_event_payload
+
+
+def main() -> int:
+    payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
+    issue = payload["issue"]
+    issue_number = issue["number"]
+    labels = [label["name"] for label in issue["labels"]]
+
+    decision = triage_issue(issue["title"], issue.get("body") or "", labels)
+    client = GitHubClient(os.environ["GITHUB_REPOSITORY"], os.environ["GITHUB_TOKEN"])
+
+    labels_to_add = [label for label in decision["add_labels"] if label not in labels]
+    labels_to_remove = [label for label in decision["remove_labels"] if label in labels]
+    client.add_labels(issue_number, labels_to_add)
+    for label in labels_to_remove:
+        client.remove_label(issue_number, label)
+
+    body_lines = [
+        f"<!-- {COMMENT_MARKERS['triage']} -->",
+        "## Agent Triage",
+        f"- Route: `{decision['state']}`",
+        f"- Issue kind: `{decision['kind']}`",
+        f"- Ambiguity: `{decision['ambiguity']}`",
+    ]
+    if decision["areas"]:
+        body_lines.append(f"- Areas affected: {', '.join(f'`{item}`' for item in decision['areas'])}")
+    if decision["likely_paths"]:
+        body_lines.append(
+            f"- Likely paths: {', '.join(f'`{item}`' for item in decision['likely_paths'])}"
+        )
+    body_lines.append("")
+    body_lines.append("### Why it landed here")
+    for reason in decision["reasons"]:
+        body_lines.append(f"- {reason}")
+
+    if decision["state"] == "agent-ready":
+        body_lines.extend(
+            [
+                "",
+                "This issue is structured enough for branch-level agent work.",
+            ]
+        )
+    else:
+        body_lines.extend(
+            [
+                "",
+                "This issue needs human clarification before an agent should implement it.",
+            ]
+        )
+
+    client.upsert_issue_comment(
+        issue_number,
+        COMMENT_MARKERS["triage"],
+        "\n".join(body_lines),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/pr_intelligence.py
+++ b/scripts/github/pr_intelligence.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Post structured review intelligence for a pull request."""
+
+from __future__ import annotations
+
+import os
+
+from blokus.automation import COMMENT_MARKERS, infer_domains_from_paths, is_sensitive_path, tests_missing
+
+from gh_helpers import GitHubClient, load_event_payload
+
+
+def _checked(body: str, fragment: str) -> bool:
+    normalized = body.lower()
+    target = fragment.lower()
+    return f"- [x] {target}" in normalized
+
+
+def main() -> int:
+    payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
+    pull_request = payload["pull_request"]
+    pull_number = pull_request["number"]
+    pr_body = pull_request.get("body") or ""
+    labels = [label["name"] for label in pull_request["labels"]]
+
+    client = GitHubClient(os.environ["GITHUB_REPOSITORY"], os.environ["GITHUB_TOKEN"])
+    files = client.list_pr_files(pull_number)
+    changed_paths = [item["filename"] for item in files]
+    impacted_domains = infer_domains_from_paths(changed_paths)
+    workflow_sensitive = any(is_sensitive_path(path) for path in changed_paths)
+    missing_test_signal = tests_missing(changed_paths) and not _checked(pr_body, "Tests updated")
+
+    add_labels = ["needs-review"]
+    if workflow_sensitive:
+        add_labels.append("workflow-sensitive")
+    client.add_labels(pull_number, [label for label in add_labels if label not in labels])
+    if "workflow-sensitive" in labels and not workflow_sensitive:
+        client.remove_label(pull_number, "workflow-sensitive")
+
+    body_lines = [
+        f"<!-- {COMMENT_MARKERS['pr_intelligence']} -->",
+        "## PR Intelligence",
+        f"- Changed files: `{len(changed_paths)}`",
+        f"- Impacted domains: {', '.join(f'`{label}`' for label in impacted_domains) or '`none inferred`'}",
+        f"- Workflow-sensitive: `{'yes' if workflow_sensitive else 'no'}`",
+        f"- Tests appear missing: `{'yes' if missing_test_signal else 'no'}`",
+        "",
+        "### Review checklist",
+        "- [ ] PR matches the linked issue and acceptance criteria.",
+        "- [ ] Tests were added or updated for behavior changes.",
+        "- [ ] CLI behavior was checked if command paths changed.",
+        "- [ ] Fixtures, schemas, or docs changed where user-facing contracts moved.",
+        "- [ ] No hidden rule-semantics change slipped in without explanation.",
+    ]
+
+    if changed_paths:
+        preview = changed_paths[:12]
+        body_lines.extend(
+            [
+                "",
+                "### Changed paths",
+                *(f"- `{path}`" for path in preview),
+            ]
+        )
+        if len(changed_paths) > len(preview):
+            body_lines.append(f"- ...and `{len(changed_paths) - len(preview)}` more")
+
+    warnings = []
+    if missing_test_signal:
+        warnings.append("Code-bearing changes landed without matching `tests/` updates.")
+    if workflow_sensitive:
+        warnings.append("The PR changes `.github/` content, so autonomous repair should stay disabled.")
+    if warnings:
+        body_lines.extend(["", "### Flags", *(f"- {warning}" for warning in warnings)])
+
+    client.upsert_issue_comment(
+        pull_number,
+        COMMENT_MARKERS["pr_intelligence"],
+        "\n".join(body_lines),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github/repair_loop.py
+++ b/scripts/github/repair_loop.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Execute one bounded autonomous repair attempt on an agent branch."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+from blokus.automation import (
+    COMMENT_MARKERS,
+    REPAIR_STATE_MARKER,
+    parse_state_marker,
+    render_state_marker,
+    repair_allowed,
+)
+
+from gh_helpers import GitHubClient, load_event_payload
+
+
+def _run(command: list[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def _has_diff() -> bool:
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _commit_and_push(branch_name: str, pull_number: int) -> str:
+    _run(["git", "config", "user.name", "github-actions[bot]"])
+    _run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"])
+    _run(["git", "add", "-A"])
+    _run(["git", "commit", "-m", f"Apply bounded repair for PR #{pull_number}"])
+    _run(["git", "push", "origin", f"HEAD:{branch_name}"])
+    return "pushed bounded repair patch"
+
+
+def main() -> int:
+    payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
+    inputs = payload["inputs"]
+    pull_number = int(inputs["pull_number"])
+    branch_name = inputs["head_branch"]
+    run_id = int(inputs["ci_run_id"])
+    category = inputs["failure_category"]
+
+    client = GitHubClient(os.environ["GITHUB_REPOSITORY"], os.environ["GITHUB_TOKEN"])
+    pull_request = client.get_pull_request(pull_number)
+    labels = [label["name"] for label in pull_request["labels"]]
+    changed_files = [item["filename"] for item in client.list_pr_files(pull_number)]
+
+    state = {"attempts": 0, "handled_runs": []}
+    for comment in reversed(client.list_issue_comments(pull_number)):
+        parsed = parse_state_marker(REPAIR_STATE_MARKER, comment.get("body", ""))
+        if parsed is not None:
+            state = parsed
+            break
+
+    handled_runs = [int(item) for item in state.get("handled_runs", [])]
+    if run_id in handled_runs:
+        return 0
+
+    retry_count = int(state.get("attempts", 0))
+    allowed, reason = repair_allowed(branch_name, labels, category, changed_files, retry_count)
+    next_state = {
+        "attempts": retry_count,
+        "handled_runs": handled_runs,
+    }
+
+    if not allowed:
+        client.remove_label(pull_number, "repair-loop")
+        client.add_labels(pull_number, ["agent-blocked", "needs-review"])
+        body = "\n".join(
+            [
+                f"<!-- {COMMENT_MARKERS['repair']} -->",
+                "## Autonomous Repair",
+                "- Status: `stopped`",
+                f"- Reason: {reason}",
+                render_state_marker(REPAIR_STATE_MARKER, next_state),
+            ]
+        )
+        client.upsert_issue_comment(pull_number, COMMENT_MARKERS["repair"], body)
+        return 0
+
+    next_state["attempts"] = retry_count + 1
+    next_state["handled_runs"] = handled_runs + [run_id]
+
+    if category == "lint":
+        _run(["./scripts/install.sh"])
+        _run([".venv/bin/python", "-m", "pip", "install", "ruff"])
+        _run([".venv/bin/ruff", "check", "--fix", "."])
+        if _has_diff():
+            action_taken = _commit_and_push(branch_name, pull_number)
+        else:
+            client.rerun_failed_jobs(run_id)
+            action_taken = "reran failed CI jobs after no deterministic lint fix applied"
+    else:
+        client.rerun_failed_jobs(run_id)
+        action_taken = "reran failed CI jobs within the bounded retry budget"
+
+    client.add_labels(pull_number, ["repair-loop"])
+    client.remove_label(pull_number, "agent-blocked")
+
+    body = "\n".join(
+        [
+            f"<!-- {COMMENT_MARKERS['repair']} -->",
+            "## Autonomous Repair",
+            "- Status: `attempted`",
+            f"- Attempt: `{next_state['attempts']}/2`",
+            f"- Failure category: `{category}`",
+            f"- Action taken: {action_taken}",
+            render_state_marker(REPAIR_STATE_MARKER, next_state),
+        ]
+    )
+    client.upsert_issue_comment(pull_number, COMMENT_MARKERS["repair"], body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/blokus/automation.py
+++ b/src/blokus/automation.py
@@ -1,0 +1,343 @@
+"""Helpers for issue, PR, and repair automation in GitHub workflows."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Iterable
+
+
+COMMENT_MARKERS = {
+    "triage": "agent-triage",
+    "entry": "agent-entry",
+    "pr_intelligence": "agent-pr-intelligence",
+    "failure_summary": "agent-failure-summary",
+    "repair": "agent-repair-loop",
+}
+
+REPAIR_STATE_MARKER = "agent-repair-loop-state"
+
+DOMAIN_LABELS = ("rules", "cli", "tests", "fixtures", "schemas", "docs", "ci")
+ALLOWED_REPAIR_CATEGORIES = {"lint", "unit-test", "cli-smoke", "fixture-schema"}
+SENSITIVE_PATH_PREFIXES = (".github/",)
+SENSITIVE_PATHS = {
+    "OWNERSHIP.md",
+    "TEAM_SUMMARY.md",
+    "docs/AGENT_POLICY.md",
+}
+
+_SECTION_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+_CHECKBOX_RE = re.compile(r"^- \[(?P<checked>[ xX])\] (?P<label>.+?)\s*$")
+_STATE_RE_TEMPLATE = r"<!-- {marker} (?P<payload>\{{.*?\}}) -->"
+
+
+def _normalize_path(value: str) -> str:
+    path = value.strip()
+    if path.startswith("./"):
+        return path[2:]
+    return path
+
+
+def parse_markdown_sections(body: str) -> dict[str, str]:
+    """Split a form-style Markdown body into named sections."""
+
+    sections: dict[str, str] = {}
+    current_name: str | None = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        match = _SECTION_RE.match(line)
+        if match:
+            if current_name is not None:
+                sections[current_name] = "\n".join(current_lines).strip()
+            current_name = match.group(1).strip().lower()
+            current_lines = []
+            continue
+        current_lines.append(line)
+
+    if current_name is not None:
+        sections[current_name] = "\n".join(current_lines).strip()
+
+    return sections
+
+
+def section_value(sections: dict[str, str], name: str) -> str:
+    """Return one form section with comments stripped."""
+
+    value = sections.get(name.lower(), "")
+    cleaned_lines = []
+    for line in value.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("<!--"):
+            continue
+        cleaned_lines.append(stripped)
+    return "\n".join(cleaned_lines).strip()
+
+
+def checked_items(section_text: str) -> tuple[str, ...]:
+    """Return the checked options from a Markdown checkbox block."""
+
+    values = []
+    for line in section_text.splitlines():
+        match = _CHECKBOX_RE.match(line.strip())
+        if match and match.group("checked").lower() == "x":
+            values.append(match.group("label").strip())
+    return tuple(values)
+
+
+def bullet_items(section_text: str) -> tuple[str, ...]:
+    """Normalize freeform textarea content into plain bullet-like items."""
+
+    values = []
+    for raw_line in section_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("<!--"):
+            continue
+        line = re.sub(r"^[-*]\s+", "", line)
+        values.append(line)
+    return tuple(values)
+
+
+def slugify(value: str) -> str:
+    """Convert a freeform string to a short branch-safe slug."""
+
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:48].rstrip("-") or "task"
+
+
+def build_agent_branch_name(issue_number: int, title: str) -> str:
+    """Build the canonical autonomous branch name for one issue."""
+
+    return f"agent/issue-{issue_number}-{slugify(title)}"
+
+
+def _detect_issue_kind(title: str, labels: Iterable[str], sections: dict[str, str]) -> str:
+    title_lower = title.lower()
+    labels_lower = {label.lower() for label in labels}
+
+    if title_lower.startswith("[rule ambiguity]:") or "rule ambiguity" in labels_lower:
+        return "rule-ambiguity"
+    if title_lower.startswith("[bug]:") or "bug" in labels_lower:
+        return "bug-report"
+    if title_lower.startswith("[agent task]:"):
+        return "agent-task"
+    if "acceptance criteria" in sections and "required tests" in sections:
+        return "agent-task"
+    return "unknown"
+
+
+def _normalize_ambiguity(value: str) -> str:
+    lowered = value.lower()
+    if "no ambiguity" in lowered:
+        return "no ambiguity"
+    if "possible ambiguity" in lowered:
+        return "possible ambiguity"
+    if "high ambiguity" in lowered:
+        return "high ambiguity"
+    return "unknown"
+
+
+def _infer_domain_labels_from_areas(areas: Iterable[str], likely_paths: Iterable[str]) -> set[str]:
+    domain_labels: set[str] = set()
+    haystack = " ".join((*areas, *likely_paths)).lower()
+
+    mapping = {
+        "src/blokus": "rules",
+        "rules": "rules",
+        "tests": "tests",
+        "fixtures": "fixtures",
+        "schemas": "schemas",
+        "docs": "docs",
+        "cli": "cli",
+        ".github": "ci",
+        "ci": "ci",
+        "workflow": "ci",
+    }
+    for needle, label in mapping.items():
+        if needle in haystack:
+            domain_labels.add(label)
+
+    return domain_labels
+
+
+def is_sensitive_path(path: str) -> bool:
+    """Return whether a path should stop autonomous repair."""
+
+    normalized = _normalize_path(path)
+    return normalized.startswith(SENSITIVE_PATH_PREFIXES) or normalized in SENSITIVE_PATHS
+
+
+def triage_issue(title: str, body: str, labels: Iterable[str]) -> dict[str, object]:
+    """Route one issue into the Phase 3 agent workflow states."""
+
+    sections = parse_markdown_sections(body)
+    kind = _detect_issue_kind(title, labels, sections)
+    ambiguity = _normalize_ambiguity(section_value(sections, "rule ambiguity"))
+    areas = checked_items(section_value(sections, "areas affected"))
+    likely_paths = bullet_items(section_value(sections, "files likely affected"))
+    domain_labels = _infer_domain_labels_from_areas(areas, likely_paths)
+    if kind == "rule-ambiguity":
+        domain_labels.add("rules")
+
+    if not domain_labels and kind in {"agent-task", "bug-report"}:
+        domain_labels.add("rules")
+
+    workflow_sensitive = any(is_sensitive_path(path) for path in likely_paths) or "ci" in domain_labels
+
+    required_sections = {
+        "agent-task": ("problem statement", "acceptance criteria", "required tests"),
+        "bug-report": ("what broke", "reproduction steps", "expected behavior", "required tests"),
+        "rule-ambiguity": ("ambiguity or decision needed", "why this blocks implementation"),
+    }.get(kind, ())
+    missing_sections = [
+        name for name in required_sections if not section_value(sections, name)
+    ]
+
+    add_labels = set(domain_labels)
+    remove_labels: set[str] = set()
+    reasons: list[str] = []
+
+    if kind == "rule-ambiguity":
+        state = "needs-human-spec"
+        add_labels.update({"needs-human-spec", "human-gate-required"})
+        remove_labels.update({"agent-ready", "agent-in-progress", "safe-autonomy"})
+        reasons.append("Rule ambiguity issues stay on the human-spec path by design.")
+    elif missing_sections:
+        state = "needs-human-spec"
+        add_labels.update({"needs-human-spec", "human-gate-required"})
+        remove_labels.update({"agent-ready", "agent-in-progress", "safe-autonomy"})
+        reasons.append(
+            "Required form sections are missing: " + ", ".join(missing_sections) + "."
+        )
+    elif ambiguity != "no ambiguity":
+        state = "needs-human-spec"
+        add_labels.update({"needs-human-spec", "human-gate-required"})
+        remove_labels.update({"agent-ready", "agent-in-progress", "safe-autonomy"})
+        reasons.append(f"Rule ambiguity is marked as `{ambiguity}`.")
+    else:
+        state = "agent-ready"
+        add_labels.add("agent-ready")
+        remove_labels.update({"needs-human-spec", "agent-blocked"})
+        reasons.append("Structured task data is complete and rule ambiguity is low.")
+
+    if workflow_sensitive:
+        add_labels.update({"workflow-sensitive", "human-gate-required", "ci"})
+        remove_labels.add("safe-autonomy")
+        reasons.append("Workflow-sensitive paths mean autonomy must stay human-gated.")
+    elif state == "agent-ready":
+        add_labels.add("safe-autonomy")
+
+    if kind == "bug-report":
+        add_labels.add("bug")
+
+    return {
+        "kind": kind,
+        "state": state,
+        "ambiguity": ambiguity,
+        "areas": sorted(areas),
+        "likely_paths": sorted(likely_paths),
+        "workflow_sensitive": workflow_sensitive,
+        "add_labels": sorted(add_labels),
+        "remove_labels": sorted(remove_labels),
+        "reasons": reasons,
+    }
+
+
+def infer_domains_from_paths(paths: Iterable[str]) -> tuple[str, ...]:
+    """Infer the review domains affected by a PR."""
+
+    domains: set[str] = set()
+    for path in paths:
+        normalized = _normalize_path(path)
+        if normalized.startswith("src/"):
+            domains.add("rules")
+        if normalized in {"src/blokus/cli.py", "src/blokus/__main__.py"}:
+            domains.add("cli")
+        if normalized.startswith("tests/"):
+            domains.add("tests")
+        if normalized.startswith("fixtures/"):
+            domains.add("fixtures")
+        if normalized.startswith("schemas/"):
+            domains.add("schemas")
+        if normalized.startswith("docs/") or normalized in {
+            "README.md",
+            "OWNERSHIP.md",
+            "TEAM_SUMMARY.md",
+        }:
+            domains.add("docs")
+        if normalized.startswith(".github/") or normalized.startswith("scripts/github/"):
+            domains.add("ci")
+    return tuple(sorted(domains))
+
+
+def tests_missing(paths: Iterable[str]) -> bool:
+    """Return whether code-bearing changes land without matching test updates."""
+
+    normalized = [_normalize_path(path) for path in paths]
+    code_touched = any(
+        path.startswith(prefix)
+        for path in normalized
+        for prefix in ("src/", "fixtures/", "schemas/")
+    )
+    tests_touched = any(path.startswith("tests/") for path in normalized)
+    return code_touched and not tests_touched
+
+
+def classify_failure_category(job_names: Iterable[str]) -> str:
+    """Map failing CI job names into the Phase 3 repair categories."""
+
+    names = [name.lower() for name in job_names]
+    if any("lint" in name for name in names):
+        return "lint"
+    if any("cli-smoke" in name or "cli smoke" in name for name in names):
+        return "cli-smoke"
+    if any("fixture-schema" in name or ("fixture" in name and "schema" in name) for name in names):
+        return "fixture-schema"
+    if any(name == "test" or "unit" in name or "tests" in name for name in names):
+        return "unit-test"
+    if any("evaluate" in name for name in names):
+        return "evaluate"
+    if any("environment" in name or "deployment" in name for name in names):
+        return "environment"
+    return "unknown"
+
+
+def repair_allowed(
+    branch_name: str,
+    labels: Iterable[str],
+    category: str,
+    changed_files: Iterable[str],
+    retry_count: int,
+) -> tuple[bool, str]:
+    """Return whether bounded autonomous repair is allowed."""
+
+    label_set = {label.lower() for label in labels}
+    if not branch_name.startswith("agent/"):
+        return False, "Branch is not agent-owned (`agent/*`)."
+    if retry_count >= 2:
+        return False, "Retry budget exhausted."
+    if category not in ALLOWED_REPAIR_CATEGORIES:
+        return False, f"Failure category `{category}` is outside the autonomous repair set."
+    if "needs-human-spec" in label_set:
+        return False, "Issue still needs human clarification."
+    if "workflow-sensitive" in label_set or "human-gate-required" in label_set:
+        return False, "Human-gated work cannot enter the repair loop."
+    if any(is_sensitive_path(path) for path in changed_files):
+        return False, "Sensitive repository automation files changed in this PR."
+    return True, "Autonomous repair is allowed."
+
+
+def render_state_marker(marker: str, payload: dict[str, object]) -> str:
+    """Embed machine-readable state inside a bot comment."""
+
+    return f"<!-- {marker} {json.dumps(payload, sort_keys=True)} -->"
+
+
+def parse_state_marker(marker: str, body: str) -> dict[str, object] | None:
+    """Extract one machine-readable state payload from a bot comment."""
+
+    pattern = re.compile(_STATE_RE_TEMPLATE.format(marker=re.escape(marker)), re.DOTALL)
+    match = pattern.search(body)
+    if not match:
+        return None
+    return json.loads(match.group("payload"))

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -1,0 +1,159 @@
+import unittest
+
+from blokus.automation import (
+    build_agent_branch_name,
+    classify_failure_category,
+    infer_domains_from_paths,
+    parse_state_marker,
+    repair_allowed,
+    render_state_marker,
+    tests_missing,
+    triage_issue,
+)
+
+
+class AutomationTests(unittest.TestCase):
+    def test_triage_marks_structured_issue_as_agent_ready(self) -> None:
+        issue_body = """
+### Problem statement
+Implement a safer CLI summary.
+
+### Acceptance criteria
+- Command output is deterministic.
+
+### Files likely affected
+- src/blokus/cli.py
+- tests/test_cli.py
+
+### Required tests
+- Update CLI tests.
+
+### Rule ambiguity
+no ambiguity
+
+### Areas affected
+- [x] src/blokus
+- [x] tests
+- [x] CLI
+""".strip()
+
+        result = triage_issue("[Agent Task]: Tighten CLI output", issue_body, [])
+
+        self.assertEqual(result["state"], "agent-ready")
+        self.assertIn("agent-ready", result["add_labels"])
+        self.assertIn("safe-autonomy", result["add_labels"])
+        self.assertIn("cli", result["add_labels"])
+        self.assertNotIn("needs-human-spec", result["add_labels"])
+
+    def test_triage_routes_ambiguous_issue_to_humans(self) -> None:
+        issue_body = """
+### Problem statement
+Clarify whether corner-touching should ignore occupied diagonals.
+
+### Acceptance criteria
+- Human confirms the exact rule.
+
+### Files likely affected
+- src/blokus/engine.py
+
+### Required tests
+- Update legality tests after decision.
+
+### Rule ambiguity
+possible ambiguity
+
+### Areas affected
+- [x] src/blokus
+""".strip()
+
+        result = triage_issue("[Agent Task]: Clarify diagonal rule", issue_body, [])
+
+        self.assertEqual(result["state"], "needs-human-spec")
+        self.assertIn("needs-human-spec", result["add_labels"])
+        self.assertIn("human-gate-required", result["add_labels"])
+        self.assertNotIn("safe-autonomy", result["add_labels"])
+
+    def test_triage_flags_workflow_sensitive_issue(self) -> None:
+        issue_body = """
+### Problem statement
+Adjust CI permissions.
+
+### Acceptance criteria
+- Workflow has least-privilege permissions.
+
+### Files likely affected
+- .github/workflows/ci.yml
+
+### Required tests
+- Trigger a CI dry run.
+
+### Rule ambiguity
+no ambiguity
+
+### Areas affected
+- [x] .github / CI workflows
+""".strip()
+
+        result = triage_issue("[Agent Task]: Tighten CI permissions", issue_body, [])
+
+        self.assertEqual(result["state"], "agent-ready")
+        self.assertIn("workflow-sensitive", result["add_labels"])
+        self.assertIn("human-gate-required", result["add_labels"])
+        self.assertNotIn("safe-autonomy", result["add_labels"])
+
+    def test_domain_inference_covers_ci_and_docs(self) -> None:
+        domains = infer_domains_from_paths(
+            [".github/workflows/ci.yml", "docs/AGENT_POLICY.md", "src/blokus/engine.py"]
+        )
+
+        self.assertEqual(domains, ("ci", "docs", "rules"))
+
+    def test_tests_missing_detects_code_without_test_changes(self) -> None:
+        self.assertTrue(tests_missing(["src/blokus/engine.py", "README.md"]))
+        self.assertFalse(tests_missing(["src/blokus/engine.py", "tests/test_engine.py"]))
+
+    def test_failure_category_mapping_prefers_specific_jobs(self) -> None:
+        self.assertEqual(classify_failure_category(["cli-smoke"]), "cli-smoke")
+        self.assertEqual(classify_failure_category(["fixture-schema"]), "fixture-schema")
+        self.assertEqual(classify_failure_category(["test"]), "unit-test")
+        self.assertEqual(classify_failure_category(["mystery-job"]), "unknown")
+
+    def test_repair_policy_blocks_sensitive_paths(self) -> None:
+        allowed, reason = repair_allowed(
+            branch_name="agent/issue-42-fix-lint",
+            labels=["agent-ready"],
+            category="lint",
+            changed_files=[".github/workflows/ci.yml"],
+            retry_count=0,
+        )
+
+        self.assertFalse(allowed)
+        self.assertIn("Sensitive", reason)
+
+    def test_repair_policy_allows_safe_agent_branch(self) -> None:
+        allowed, reason = repair_allowed(
+            branch_name="agent/issue-42-fix-lint",
+            labels=["agent-ready", "safe-autonomy"],
+            category="lint",
+            changed_files=["src/blokus/engine.py", "tests/test_engine.py"],
+            retry_count=1,
+        )
+
+        self.assertTrue(allowed)
+        self.assertIn("allowed", reason.lower())
+
+    def test_branch_name_slug_is_bounded(self) -> None:
+        branch = build_agent_branch_name(12, "[Agent Task]: Normalize CLI output and fixture docs")
+
+        self.assertTrue(branch.startswith("agent/issue-12-"))
+        self.assertLessEqual(len(branch.split("-", 3)[-1]), 48)
+
+    def test_state_marker_round_trips(self) -> None:
+        rendered = render_state_marker("agent-repair-loop-state", {"attempts": 1, "handled_runs": [7]})
+        parsed = parse_state_marker("agent-repair-loop-state", rendered)
+
+        self.assertEqual(parsed, {"attempts": 1, "handled_runs": [7]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add the Phase 3 agentic control layer on top of the existing governance and CI foundation.

- add structured issue forms for agent tasks, bugs, and rule ambiguity
- add label taxonomy and AGENT_POLICY documentation for bounded autonomy
- add issue triage, agent entry, PR intelligence, failure summary, and repair-loop workflows
- add tested Python helpers for issue routing, domain inference, CI failure classification, and repair policy
- tighten the PR template for agent-generated work

## Validation
- `python3 -m compileall src scripts/github tests`
- `./scripts/test.sh`
- `./scripts/cli_smoke.sh`
- `./scripts/validate_fixtures.sh`
- `./scripts/evaluate.sh`
- `ruff check .`

## Notes
- The repair loop only acts on `agent/*` branches.
- Workflow-sensitive changes under `.github/` are documented and intentionally excluded from autonomous repair.
- GitHub issue-event workflows can only be fully dry-run after these files land on the default branch.
