### PR TITLE
[codex] Add Phase 4 release automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,39 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - implementation
+        - classic
+        - duo
+        - shared-engine
+        - rules
+        - cli
+    - title: Fixes
+      labels:
+        - bug
+        - counterexample
+    - title: Tests And Quality
+      labels:
+        - testing
+        - tests
+        - fixtures
+        - schemas
+    - title: Documentation
+      labels:
+        - documentation
+        - docs
+        - review
+    - title: CI And Automation
+      labels:
+        - ci
+        - workflow-sensitive
+        - agent-ready
+        - agent-in-progress
+        - repair-loop
+    - title: Governance And Decisions
+      labels:
+        - decision
+        - human-gate-required
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/promote-submission.yml
+++ b/.github/workflows/promote-submission.yml
@@ -1,0 +1,157 @@
+name: promote-submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release-candidate tag to promote
+        required: true
+        type: string
+      final_tag:
+        description: Optional final release tag override
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      final_tag: ${{ steps.meta.outputs.final_tag }}
+      target_commitish: ${{ steps.meta.outputs.target_commitish }}
+      release_name: ${{ steps.meta.outputs.release_name }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Resolve release metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_FINAL_TAG: ${{ inputs.final_tag }}
+          PYTHONPATH: src
+        run: |
+          mkdir -p dist/submission
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${INPUT_RELEASE_TAG}" > dist/submission/release.json
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+
+          from blokus.release import final_tag_from_rc
+
+          payload = json.loads(Path("dist/submission/release.json").read_text(encoding="utf-8"))
+          release_tag = os.environ["INPUT_RELEASE_TAG"].strip()
+          final_tag = os.environ.get("INPUT_FINAL_TAG", "").strip() or final_tag_from_rc(release_tag)
+          target_commitish = payload.get("target_commitish") or "HEAD"
+          notes = (payload.get("body") or "").strip()
+          Path("dist/submission/release-body.md").write_text(notes + "\n", encoding="utf-8")
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"release_tag={release_tag}\n")
+              handle.write(f"final_tag={final_tag}\n")
+              handle.write(f"target_commitish={target_commitish}\n")
+              handle.write(f"release_name=Blokus Focus Pokus {final_tag}\n")
+          PY
+      - name: Upload metadata artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-metadata-${{ steps.meta.outputs.release_tag }}
+          path: dist/submission/release-body.md
+          if-no-files-found: error
+
+  fetch-rc:
+    runs-on: ubuntu-latest
+    needs: metadata
+    steps:
+      - name: Download RC assets from GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          FINAL_TAG: ${{ needs.metadata.outputs.final_tag }}
+        run: |
+          mkdir -p dist/submission/assets
+          gh release download "${RELEASE_TAG}" --dir dist/submission/assets --clobber
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from datetime import UTC, datetime
+          from pathlib import Path
+
+          manifest = {
+              "source_release_tag": os.environ["RELEASE_TAG"],
+              "final_release_tag": os.environ["FINAL_TAG"],
+              "promoted_by": os.environ["GITHUB_ACTOR"],
+              "promoted_at": datetime.now(UTC).isoformat(),
+          }
+          Path("dist/submission/submission-manifest.json").write_text(
+              json.dumps(manifest, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Upload submission candidate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: submission-candidate-${{ needs.metadata.outputs.release_tag }}
+          path: dist/submission/
+          if-no-files-found: error
+
+  submission-approval:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - fetch-rc
+    environment:
+      name: submission
+    steps:
+      - run: echo "Submission approval granted; final publication may proceed."
+
+  publish-submission:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - fetch-rc
+      - submission-approval
+    steps:
+      - name: Download submission candidate artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: submission-candidate-${{ needs.metadata.outputs.release_tag }}
+          path: dist/submission
+      - name: Download submission metadata artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: submission-metadata-${{ needs.metadata.outputs.release_tag }}
+          path: dist/submission/meta
+      - name: Publish final GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          FINAL_TAG: ${{ needs.metadata.outputs.final_tag }}
+          TARGET_COMMITISH: ${{ needs.metadata.outputs.target_commitish }}
+          RELEASE_NAME: ${{ needs.metadata.outputs.release_name }}
+        run: |
+          cp dist/submission/meta/release-body.md dist/submission/final-notes.md
+          printf '\n\nPromoted from `%s` through the protected `submission` environment.\n' "${RELEASE_TAG}" >> dist/submission/final-notes.md
+
+          if gh release view "${FINAL_TAG}" >/dev/null 2>&1; then
+            gh release upload "${FINAL_TAG}" dist/submission/assets/* dist/submission/submission-manifest.json --clobber
+            gh release edit "${FINAL_TAG}" \
+              --title "${RELEASE_NAME}" \
+              --notes-file dist/submission/final-notes.md
+          else
+            gh release create "${FINAL_TAG}" dist/submission/assets/* dist/submission/submission-manifest.json \
+              --title "${RELEASE_NAME}" \
+              --notes-file dist/submission/final-notes.md \
+              --target "${TARGET_COMMITISH}"
+          fi

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,220 @@
+name: release-candidate
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Optional release-candidate tag override
+        required: false
+        type: string
+      publish_release:
+        description: Create or update the GitHub pre-release after rc approval
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      release_name: ${{ steps.meta.outputs.release_name }}
+      archive_name: ${{ steps.meta.outputs.archive_name }}
+      publish_release: ${{ steps.meta.outputs.publish_release }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags --force
+      - name: Compute release metadata
+        id: meta
+        env:
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+          INPUT_PUBLISH_RELEASE: ${{ inputs.publish_release }}
+          PYTHONPATH: src
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          import subprocess
+          import tomllib
+          from pathlib import Path
+
+          from blokus.release import next_rc_tag
+
+          project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          version = project["project"]["version"]
+          requested_tag = os.getenv("INPUT_RELEASE_TAG", "").strip()
+          existing_tags = subprocess.run(
+              ["git", "tag", "--list", f"v{version}-rc.*"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.splitlines()
+          release_tag = requested_tag or next_rc_tag(version, existing_tags)
+          publish_release = "true" if (
+              os.getenv("GITHUB_EVENT_NAME") == "push"
+              or os.getenv("INPUT_PUBLISH_RELEASE", "false") == "true"
+          ) else "false"
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as handle:
+              handle.write(f"release_tag={release_tag}\n")
+              handle.write(f"release_name=Blokus Focus Pokus {release_tag}\n")
+              handle.write(f"archive_name=blokus-focus-pokus-{release_tag}.tar.gz\n")
+              handle.write(f"publish_release={publish_release}\n")
+          PY
+
+  verify-main:
+    runs-on: ubuntu-latest
+    needs: metadata
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install project
+        run: ./scripts/install.sh
+      - name: Run tests
+        run: ./scripts/test.sh
+      - name: Run CLI smoke checks
+        run: ./scripts/cli_smoke.sh
+      - name: Run fixture/schema validation
+        run: ./scripts/validate_fixtures.sh
+      - name: Run evaluation harness
+        run: ./scripts/evaluate.sh
+
+  package:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - verify-main
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install project
+        run: ./scripts/install.sh
+      - name: Package release candidate
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          ARCHIVE_NAME: ${{ needs.metadata.outputs.archive_name }}
+        run: ./scripts/package_release.sh
+      - name: Upload release candidate artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-${{ needs.metadata.outputs.release_tag }}
+          path: |
+            dist/release-candidate/
+            dist/${{ needs.metadata.outputs.archive_name }}
+          if-no-files-found: error
+
+  release-notes:
+    runs-on: ubuntu-latest
+    needs: metadata
+    steps:
+      - name: Generate release notes preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+        run: |
+          mkdir -p dist/release-notes
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="${RELEASE_TAG}" \
+            -f target_commitish="${GITHUB_SHA}" \
+            > dist/release-notes/release-notes.json
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("dist/release-notes/release-notes.json").read_text(encoding="utf-8"))
+          Path("dist/release-notes/release-notes.md").write_text(
+              (payload.get("body") or "").strip() + "\n",
+              encoding="utf-8",
+          )
+          Path("dist/release-notes/release-title.txt").write_text(
+              (payload.get("name") or "").strip() + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes-${{ needs.metadata.outputs.release_tag }}
+          path: dist/release-notes/
+          if-no-files-found: error
+
+  rc-approval:
+    runs-on: ubuntu-latest
+    needs:
+      - package
+      - release-notes
+    environment:
+      name: rc
+    steps:
+      - run: echo "RC approval granted; pre-release publication may proceed."
+
+  publish-rc:
+    runs-on: ubuntu-latest
+    needs:
+      - metadata
+      - package
+      - release-notes
+      - rc-approval
+    if: needs.metadata.outputs.publish_release == 'true'
+    steps:
+      - name: Download release candidate artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-candidate-${{ needs.metadata.outputs.release_tag }}
+          path: dist/release-assets
+      - name: Download release notes artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes-${{ needs.metadata.outputs.release_tag }}
+          path: dist/release-notes
+      - name: Create or update GitHub pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.release_tag }}
+          RELEASE_NAME: ${{ needs.metadata.outputs.release_name }}
+          ARCHIVE_NAME: ${{ needs.metadata.outputs.archive_name }}
+        run: |
+          ARCHIVE_PATH="dist/release-assets/${ARCHIVE_NAME}"
+          EVIDENCE_PATH="dist/release-assets/release-candidate/evidence-delta.md"
+          NOTES_PATH="dist/release-notes/release-notes.md"
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" \
+              "${ARCHIVE_PATH}" \
+              "${EVIDENCE_PATH}" \
+              "${NOTES_PATH}#release-notes.md" \
+              --clobber
+            gh release edit "${RELEASE_TAG}" \
+              --title "${RELEASE_NAME}" \
+              --notes-file "${NOTES_PATH}" \
+              --prerelease
+          else
+            gh release create "${RELEASE_TAG}" \
+              "${ARCHIVE_PATH}" \
+              "${EVIDENCE_PATH}" \
+              "${NOTES_PATH}#release-notes.md" \
+              --title "${RELEASE_NAME}" \
+              --notes-file "${NOTES_PATH}" \
+              --target "${GITHUB_SHA}" \
+              --prerelease
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blocus Focus Pokus
 
-Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 extends the same engine to Duo through mode configuration. Phase 3 adds structured issue intake, PR intelligence, and bounded branch-level agent repair.
+Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 extends the same engine to Duo through mode configuration. Phase 3 adds structured issue intake, PR intelligence, and bounded branch-level agent repair. Phase 4 adds release-candidate packaging and protected-environment delivery gates.
 
 ## Project purpose
 
@@ -14,6 +14,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - Phase 1 baseline: Classic mode, 4 players, JSON state I/O, legality checks, move application, legal-move generation, simple computer player, tests, and fixtures.
 - Phase 2 direction: Duo mode by configuration in the same engine (`ModeConfig` extension + tests/fixtures), not by a separate engine.
 - Phase 3 direction: structured issue forms, label-driven agent entry, PR review intelligence, and bounded autonomous repair on `agent/*` branches.
+- Phase 4 direction: automated release-candidate packaging, evidence bundles, GitHub pre-releases, and protected `rc` / `submission` approval gates.
 
 ## Repository structure
 
@@ -24,6 +25,8 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - `schemas/`: JSON contracts for game state, move, and mode configuration.
 - `docs/`: requirements, architecture, contracts, review discipline, traceability, issue seeds, evidence, and AI usage logs.
 - `.github/workflows/ci.yml`: CI lint + test + CLI smoke + fixture/schema + evaluation pipeline.
+- `.github/workflows/release-candidate.yml`: release-candidate packaging and protected `rc` publication flow.
+- `.github/workflows/promote-submission.yml`: manual promotion through the protected `submission` gate.
 - `.github/pull_request_template.md`: merge checklist with requirements/evidence/review gates.
 - `.github/ISSUE_TEMPLATE/`: structured issue intake for agent tasks, bugs, and rule ambiguity.
 - `.github/CODEOWNERS`: review routing for owned paths and governance checks.
@@ -38,6 +41,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - Team/report snapshot: `TEAM_SUMMARY.md`.
 - Phase 1 governance setup: `docs/phase1-governance.md`.
 - Phase 3 policy and autonomy boundary: `docs/AGENT_POLICY.md`.
+- Release contents and policy: `docs/RELEASE_CONTENTS.md`, `docs/RELEASE_POLICY.md`.
 - Evidence: `docs/evidence-log.md`.
 - AI usage disclosure: `docs/ai-usage.md`.
 

--- a/docs/RELEASE_CONTENTS.md
+++ b/docs/RELEASE_CONTENTS.md
@@ -1,0 +1,54 @@
+# Release Contents
+
+This document defines the artifact bundle produced by the Phase 4 release automation.
+
+## Required contents
+
+Each release candidate must include the following:
+
+- source snapshot archive generated from the current commit
+- automated test output summary
+- CLI smoke output summary
+- fixture/schema validation summary
+- evaluation summary
+- machine-generated evidence delta
+- release metadata file
+- automated release notes generated as a workflow artifact and attached to the GitHub Release
+- release policy and release contents references
+
+## Optional contents
+
+The workflow may also include:
+
+- example state JSON generated from the CLI
+- rendered board output for the generated example state
+- additional notes or supplementary artifacts attached to the GitHub Release
+
+## Naming convention
+
+- release candidate tag: `v<version>-rc.<n>`
+- final submission tag by default: `v<version>`
+- release bundle archive: `blokus-focus-pokus-<tag>.tar.gz`
+
+## Workflow artifact layout
+
+The release workflow stores generated files under `dist/release-candidate/` before uploading them as workflow artifacts.
+Release notes are generated separately under `dist/release-notes/` and uploaded alongside the package artifact.
+
+Expected layout:
+
+```text
+dist/
+  release-candidate/
+    docs/
+    examples/
+    logs/
+    source/
+    evidence-delta.md
+    release-metadata.json
+  blokus-focus-pokus-<tag>.tar.gz
+```
+
+## Review expectation
+
+The `rc` environment gate should review the uploaded release-candidate artifact bundle together with the generated release notes. The `submission` gate should review the approved RC artifact plus the promotion manifest before final publication.

--- a/docs/RELEASE_POLICY.md
+++ b/docs/RELEASE_POLICY.md
@@ -1,0 +1,86 @@
+# Release Policy
+
+## Purpose
+
+Phase 4 extends the repository from supervised autonomous development into supervised delivery. The delivery loop may package, summarize, and publish artifacts automatically, but it must stop at protected environment gates until a human reviewer approves progress.
+
+## RC Generation
+
+The `release-candidate` workflow is the release entrypoint.
+
+It runs when:
+
+- code is pushed to `main`
+- a human manually dispatches the workflow for a controlled rerun
+
+The workflow must:
+
+- verify the merged code with install, test, CLI smoke, fixture/schema validation, and evaluation
+- build the release-candidate artifact bundle
+- generate release notes and an evidence delta
+- upload artifacts for review before any release publication happens
+
+## RC Approval
+
+The `rc` environment is the first trust boundary.
+
+Rules:
+
+- `rc` approval is required before the workflow may publish or update a GitHub pre-release
+- self-review must remain disabled
+- the author of the merged PR should not be the reviewer who approves the environment
+
+## GitHub Pre-Release Publication
+
+After `rc` approval, the workflow may create or update a GitHub pre-release:
+
+- tag scheme: `v<version>-rc.<n>` unless a manual override is supplied
+- release type: GitHub pre-release
+- assets: packaged archive plus evidence-oriented artifacts
+- notes: generated automatically through GitHub release-note generation
+
+## Submission Promotion
+
+The `promote-submission` workflow is a manual workflow-dispatch step.
+
+It must:
+
+- accept an approved RC tag
+- retrieve the RC assets
+- prepare a submission manifest
+- pause at the `submission` environment for approval
+- publish or update the final GitHub Release only after approval
+
+By default, the final submission tag is the RC version with the `-rc.<n>` suffix removed. A manual override may be supplied when needed.
+
+## Reviewer Rules
+
+- `rc` reviewers: any configured reviewer except the initiating actor when self-review prevention is enabled
+- `submission` reviewers: same reviewer policy, with the expectation that a non-author approves
+- humans still control protected environments, merges to `main`, and any sensitive repository settings
+
+## Blocking Conditions
+
+Release publication must stop when any of the following are true:
+
+- verification commands fail
+- packaging fails
+- evidence or release metadata cannot be generated
+- the environment gate is not approved
+- the final release tag would be ambiguous and no human override is provided
+
+## Failure Handling And Reruns
+
+- use `workflow_dispatch` on `release-candidate` to rerun packaging for the same ref without merging new code
+- use `workflow_dispatch` on `promote-submission` to retry final promotion from an existing RC tag
+- reruns do not bypass `rc` or `submission` approval gates
+- reruns should reuse the existing release tag when the intent is to update the same candidate
+
+## Artifact Review Checklist
+
+Before approving `rc` or `submission`, reviewers should confirm:
+
+- the archive exists and opens correctly
+- the evidence delta matches the expected merged change set
+- the evaluation summary is present and successful
+- any docs, fixtures, schemas, or CI-sensitive changes are visible and intentional

--- a/scripts/generate_evidence_delta.sh
+++ b/scripts/generate_evidence_delta.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <output-path> <test-log-path> <evaluate-log-path>" >&2
+  exit 1
+fi
+
+OUTPUT_PATH="$1"
+TEST_LOG_PATH="$2"
+EVALUATE_LOG_PATH="$3"
+
+if [ -f .venv/bin/activate ]; then
+  . .venv/bin/activate
+else
+  export PYTHONPATH=src
+fi
+
+export OUTPUT_PATH TEST_LOG_PATH EVALUATE_LOG_PATH
+
+python - <<'PY'
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+from blokus.release import classify_release_areas, extract_bullets_under_heading
+
+
+def git(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+output_path = Path(os.environ["OUTPUT_PATH"])
+test_log_path = Path(os.environ["TEST_LOG_PATH"])
+evaluate_log_path = Path(os.environ["EVALUATE_LOG_PATH"])
+
+try:
+    base_tag = git("describe", "--tags", "--abbrev=0", "--match", "v*", "HEAD^")
+except subprocess.CalledProcessError:
+    base_tag = ""
+
+if base_tag:
+    compare_range = f"{base_tag}..HEAD"
+    changed_paths = git("diff", "--name-only", compare_range).splitlines()
+    log_lines = git("log", "--pretty=%H%x09%s", compare_range).splitlines()
+else:
+    compare_range = "initial release candidate"
+    changed_paths = git("ls-tree", "-r", "--name-only", "HEAD").splitlines()
+    log_lines = git("log", "--pretty=%H%x09%s", "HEAD").splitlines()
+
+ignored_prefixes = (".idea/", "artifacts/", "dist/", ".venv/")
+changed_paths = [
+    path for path in changed_paths
+    if path and not path.startswith(ignored_prefixes) and "__pycache__" not in path
+]
+
+areas = classify_release_areas(changed_paths)
+seen_prs: set[str] = set()
+merged_prs: list[tuple[str, str]] = []
+for line in log_lines:
+    if "\t" not in line:
+        continue
+    _, subject = line.split("\t", 1)
+    for pr_number in re.findall(r"#(\d+)", subject):
+        if pr_number not in seen_prs:
+            seen_prs.add(pr_number)
+            merged_prs.append((pr_number, subject))
+
+
+def last_non_empty_line(path: Path) -> str:
+    if not path.exists():
+        return "Log not available."
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return lines[-1] if lines else "Log was empty."
+
+
+requirements_text = Path("docs/requirements.md").read_text(encoding="utf-8")
+open_risks = extract_bullets_under_heading(requirements_text, "Open risks and open issues")
+
+body_lines = [
+    "# Evidence Delta",
+    "",
+    f"- Generated at: `{datetime.now(UTC).isoformat()}`",
+    f"- Commit: `{git('rev-parse', 'HEAD')}`",
+    f"- Comparison base: `{base_tag or 'none'}`",
+    f"- Comparison range: `{compare_range}`",
+    f"- Changed areas: {', '.join(f'`{area}`' for area in areas) or '`none detected`'}",
+    f"- Test summary: `{last_non_empty_line(test_log_path)}`",
+    f"- Evaluation summary: `{last_non_empty_line(evaluate_log_path)}`",
+    "",
+    "## Merged PRs since the comparison base",
+]
+
+if merged_prs:
+    body_lines.extend(f"- PR #{number}: {subject}" for number, subject in merged_prs)
+else:
+    body_lines.append("- No PR numbers were detected in commit subjects for this range.")
+
+body_lines.extend(["", "## Changed files by area"])
+if changed_paths:
+    preview = changed_paths[:20]
+    body_lines.extend(f"- `{path}`" for path in preview)
+    if len(changed_paths) > len(preview):
+        body_lines.append(f"- ...and `{len(changed_paths) - len(preview)}` more")
+else:
+    body_lines.append("- No changed files detected.")
+
+body_lines.extend(["", "## Open risks carried into this candidate"])
+if open_risks:
+    body_lines.extend(f"- {risk}" for risk in open_risks)
+else:
+    body_lines.append("- No open risks were extracted from `docs/requirements.md`.")
+
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text("\n".join(body_lines) + "\n", encoding="utf-8")
+PY

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_ROOT="${1:-dist/release-candidate}"
+RELEASE_TAG="${RELEASE_TAG:-dev-$(git rev-parse --short HEAD)}"
+ARCHIVE_NAME="${ARCHIVE_NAME:-blokus-focus-pokus-${RELEASE_TAG}.tar.gz}"
+
+rm -rf "$OUTPUT_ROOT"
+mkdir -p "$OUTPUT_ROOT/logs" "$OUTPUT_ROOT/docs" "$OUTPUT_ROOT/examples" "$OUTPUT_ROOT/source"
+
+if [ -f .venv/bin/activate ]; then
+  . .venv/bin/activate
+else
+  export PYTHONPATH=src
+fi
+
+./scripts/test.sh 2>&1 | tee "$OUTPUT_ROOT/logs/test-output.txt"
+./scripts/cli_smoke.sh 2>&1 | tee "$OUTPUT_ROOT/logs/cli-smoke-output.txt"
+./scripts/validate_fixtures.sh 2>&1 | tee "$OUTPUT_ROOT/logs/fixture-schema-output.txt"
+./scripts/evaluate.sh 2>&1 | tee "$OUTPUT_ROOT/logs/evaluate-output.txt"
+
+python -m blokus new --mode classic --output "$OUTPUT_ROOT/examples/classic-initial.json"
+python -m blokus show --state "$OUTPUT_ROOT/examples/classic-initial.json" > "$OUTPUT_ROOT/examples/classic-render.txt"
+
+for path in \
+  README.md \
+  OWNERSHIP.md \
+  TEAM_SUMMARY.md \
+  docs/AGENT_POLICY.md \
+  docs/RELEASE_CONTENTS.md \
+  docs/RELEASE_POLICY.md \
+  docs/evidence-log.md \
+  docs/traceability-matrix.md \
+  docs/ai-usage.md
+do
+  cp "$path" "$OUTPUT_ROOT/docs/"
+done
+
+git archive --format=tar.gz --output "$OUTPUT_ROOT/source/blokus-focus-pokus-${RELEASE_TAG}-source.tar.gz" HEAD
+
+./scripts/generate_evidence_delta.sh \
+  "$OUTPUT_ROOT/evidence-delta.md" \
+  "$OUTPUT_ROOT/logs/test-output.txt" \
+  "$OUTPUT_ROOT/logs/evaluate-output.txt"
+
+export OUTPUT_ROOT RELEASE_TAG ARCHIVE_NAME
+
+python - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+output_root = Path(os.environ["OUTPUT_ROOT"])
+release_tag = os.environ["RELEASE_TAG"]
+archive_name = os.environ["ARCHIVE_NAME"]
+
+metadata = {
+    "release_tag": release_tag,
+    "archive_name": archive_name,
+    "generated_at": datetime.now(UTC).isoformat(),
+    "commit": subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip(),
+    "artifacts": {
+        "evidence_delta": "evidence-delta.md",
+        "logs": [
+            "logs/test-output.txt",
+            "logs/cli-smoke-output.txt",
+            "logs/fixture-schema-output.txt",
+            "logs/evaluate-output.txt",
+        ],
+        "example_state": "examples/classic-initial.json",
+        "example_render": "examples/classic-render.txt",
+    },
+}
+
+(output_root / "release-metadata.json").write_text(
+    json.dumps(metadata, indent=2) + "\n",
+    encoding="utf-8",
+)
+PY
+
+mkdir -p dist
+tar -czf "dist/${ARCHIVE_NAME}" -C "$(dirname "$OUTPUT_ROOT")" "$(basename "$OUTPUT_ROOT")"
+echo "Created dist/${ARCHIVE_NAME}"

--- a/src/blokus/release.py
+++ b/src/blokus/release.py
@@ -1,0 +1,78 @@
+"""Release automation helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+
+_RC_TAG_PATTERN = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)-rc\.(?P<index>\d+)$")
+
+
+def next_rc_tag(version: str, existing_tags: Iterable[str]) -> str:
+    """Return the next monotonically increasing RC tag for one version."""
+
+    highest = 0
+    for tag in existing_tags:
+        match = _RC_TAG_PATTERN.match(tag.strip())
+        if match and match.group("version") == version:
+            highest = max(highest, int(match.group("index")))
+    return f"v{version}-rc.{highest + 1}"
+
+
+def final_tag_from_rc(rc_tag: str) -> str:
+    """Return the default final tag derived from an RC tag."""
+
+    match = _RC_TAG_PATTERN.match(rc_tag.strip())
+    if not match:
+        return rc_tag.strip()
+    return f"v{match.group('version')}"
+
+
+def classify_release_areas(paths: Iterable[str]) -> tuple[str, ...]:
+    """Classify changed files into review-friendly release areas."""
+
+    areas: set[str] = set()
+    for raw_path in paths:
+        path = raw_path.strip()
+        if not path:
+            continue
+        if path.startswith("src/"):
+            areas.add("source")
+        if path.startswith("tests/"):
+            areas.add("tests")
+        if path.startswith("fixtures/"):
+            areas.add("fixtures")
+        if path.startswith("schemas/"):
+            areas.add("schemas")
+        if path.startswith("docs/") or path in {"README.md", "OWNERSHIP.md", "TEAM_SUMMARY.md"}:
+            areas.add("docs")
+        if path.startswith(".github/") or path.startswith("scripts/github/"):
+            areas.add("ci")
+        if path.startswith("scripts/") and not path.startswith("scripts/github/"):
+            areas.add("scripts")
+    return tuple(sorted(areas))
+
+
+def extract_bullets_under_heading(markdown: str, heading: str) -> tuple[str, ...]:
+    """Extract the bullet list under one Markdown heading."""
+
+    target = heading.strip().lower()
+    current_heading: str | None = None
+    bullets: list[str] = []
+
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            current_heading = stripped.lstrip("#").strip().lower()
+            continue
+        if current_heading != target:
+            continue
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+            continue
+        if bullets and stripped.startswith("#"):
+            break
+    return tuple(bullets)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,55 @@
+import unittest
+
+from blokus.release import (
+    classify_release_areas,
+    extract_bullets_under_heading,
+    final_tag_from_rc,
+    next_rc_tag,
+)
+
+
+class ReleaseHelpersTests(unittest.TestCase):
+    def test_next_rc_tag_increments_highest_known_candidate(self) -> None:
+        tag = next_rc_tag("0.1.0", ["v0.1.0-rc.1", "v0.1.0-rc.3", "v0.0.9-rc.2"])
+
+        self.assertEqual(tag, "v0.1.0-rc.4")
+
+    def test_final_tag_from_rc_strips_release_candidate_suffix(self) -> None:
+        self.assertEqual(final_tag_from_rc("v0.1.0-rc.2"), "v0.1.0")
+        self.assertEqual(final_tag_from_rc("v0.1.0"), "v0.1.0")
+
+    def test_classify_release_areas_groups_expected_paths(self) -> None:
+        areas = classify_release_areas(
+            [
+                "src/blokus/engine.py",
+                "tests/test_engine.py",
+                "fixtures/states/classic_initial.json",
+                "docs/RELEASE_POLICY.md",
+                ".github/workflows/release-candidate.yml",
+                "scripts/package_release.sh",
+            ]
+        )
+
+        self.assertEqual(areas, ("ci", "docs", "fixtures", "scripts", "source", "tests"))
+
+    def test_extract_bullets_under_heading_reads_open_risks(self) -> None:
+        markdown = """
+# Requirements
+
+## Open risks and open issues
+
+- First risk
+- Second risk
+
+## Another heading
+
+- Ignore me
+""".strip()
+
+        bullets = extract_bullets_under_heading(markdown, "Open risks and open issues")
+
+        self.assertEqual(bullets, ("First risk", "Second risk"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add the Phase 4 supervised delivery loop on top of the Phase 3 agentic branch work.

- add release contents and release policy docs for RC and submission gates
- add release helper code plus tests for tag/version and release-area logic
- add packaging and evidence-delta scripts for the release-candidate bundle
- add GitHub release-note categorization via `.github/release.yml`
- add `release-candidate.yml` and `promote-submission.yml` with protected `rc` and `submission` environment gates

## Validation
- `python3 -m compileall src scripts tests`
- `./scripts/install.sh`
- `./scripts/test.sh`
- `RELEASE_TAG=v0.1.0-rc.local ARCHIVE_NAME=blokus-focus-pokus-v0.1.0-rc.local.tar.gz ./scripts/package_release.sh`
- `ruff check .`

## Notes
- This PR is intentionally stacked on top of #32 because Phase 4 depends on the Phase 3 label, policy, and workflow foundation.
- Manual workflow dry runs can be executed on this branch before anything is merged to `main`.
- The delivery workflows stop at `rc` and `submission`; they do not grant autonomous approval authority.
