### PR TITLE
[codex] Add team GitHub CI/CD guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,49 @@
+# Repository instructions for GitHub Copilot
+
+This repository uses plain Python with reproducible shell-script entrypoints. Prefer the documented project commands instead of inventing one-off setup or validation steps.
+
+## Working style
+
+- Keep changes scoped to the linked issue or pull request.
+- Do not suggest or perform direct pushes to `main`.
+- Assume all changes reach `main` through a pull request with human review.
+- Preserve the current trust boundaries around protected branches and protected environments.
+
+## Validation
+
+Use the repository scripts whenever they are relevant:
+
+- `./scripts/install.sh`
+- `./scripts/test.sh`
+- `./scripts/cli_smoke.sh`
+- `./scripts/validate_fixtures.sh`
+- `./scripts/evaluate.sh`
+
+If you change code, tests, fixtures, schemas, or CLI behavior, prefer the matching script rather than an ad hoc command.
+
+## Repository priorities
+
+- Keep behavior deterministic and reproducible.
+- Keep fixtures and schemas aligned with implementation changes.
+- Update tests for behavior changes.
+- Update documentation when contracts, release flow, or operational expectations change.
+- Call out assumptions clearly in pull requests, especially around rule behavior.
+
+## Sensitive boundaries
+
+- Do not relax branch protection, environment approval, or review requirements.
+- Do not introduce secrets, tokens, or copied credentials into code, docs, logs, or artifacts.
+- Treat `.github/`, workflow permissions, release policy, and incident policy as sensitive and human-gated.
+- Do not introduce new third-party GitHub Actions without explicit human approval.
+
+## Current merge gates on `main`
+
+The required checks on `main` are:
+
+- `lint`
+- `test`
+- `cli-smoke`
+- `fixture-schema`
+- `evaluate`
+
+Additional security-oriented checks may also run, including CodeQL and dependency review.

--- a/.github/instructions/rules.instructions.md
+++ b/.github/instructions/rules.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "src/blokus/**,tests/**,fixtures/**,schemas/**"
+---
+
+These files define game behavior, correctness, and reproducibility.
+
+- Do not invent or silently change rule semantics. If requirements, fixtures, and expected behavior disagree, stop and escalate.
+- Update tests whenever behavior changes.
+- Keep fixtures and schemas synchronized with implementation changes.
+- Preserve deterministic CLI and serialization behavior where possible.
+- Prefer small, explicit changes over broad refactors when touching game rules.
+- When editing tests, make the expected behavior obvious from the test name and assertions.
+- When editing fixtures or schemas, explain in the PR why the contract changed and which tests validate it.

--- a/.github/instructions/workflows.instructions.md
+++ b/.github/instructions/workflows.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: ".github/**,scripts/github/**,docs/AGENT_POLICY.md,docs/PIPELINE_SECURITY.md,docs/INCIDENT_RESPONSE.md,docs/RELEASE_POLICY.md,docs/RELEASE_CONTENTS.md"
+---
+
+These files are part of the repository's governance and delivery trust boundary.
+
+- Keep GitHub Actions permissions minimal. Prefer `contents: read` by default and raise permissions only for the exact job that needs them.
+- Do not relax pull-request review, CODEOWNERS, status-check, or environment-approval controls.
+- Do not add new third-party GitHub Actions unless a human explicitly requests and reviews that addition.
+- Preserve the `rc` and `submission` environment gates. Packaging happens before approval; publication happens after approval.
+- If a workflow change could affect merge authority, secret scope, release publication, or repair-loop behavior, mark it as human-gated in the PR explanation.
+- Do not "fix" CI by weakening policy. Fix the underlying workflow or code instead.
+- Keep comments and automation output concise, auditable, and easy for human reviewers to follow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Agent Instructions
+
+These instructions are for AI agents working in this repository.
+
+## Scope and branch rules
+
+- Work only on issue-scoped branches.
+- The `agent/*` prefix is reserved for autonomous branch work.
+- Never merge to `main`.
+- Never bypass pull-request review or protected-environment approval.
+- Keep changes tightly scoped to the linked issue.
+
+## What to read first
+
+Before making changes, ground yourself in the repository documents that match the task:
+
+- `docs/requirements.md`
+- `docs/AGENT_POLICY.md`
+- `docs/RELEASE_POLICY.md`
+- `docs/PIPELINE_SECURITY.md`
+- `docs/GITHUB_CICD_GUIDE.md`
+
+Use the smallest relevant context bundle rather than loading every document at once.
+
+## Validation commands
+
+Use the repository scripts as the canonical validation surface:
+
+- `./scripts/install.sh`
+- `./scripts/test.sh`
+- `./scripts/cli_smoke.sh`
+- `./scripts/validate_fixtures.sh`
+- `./scripts/evaluate.sh`
+
+## Hard stops
+
+Stop and escalate instead of guessing when any of the following are true:
+
+- rule semantics are ambiguous
+- the task needs repository settings, secrets, branch protection, or environment changes
+- `.github/` changes would widen permissions or alter trust boundaries
+- the task wants to widen scope beyond the linked issue
+- release artifacts, evidence, or provenance do not match expectations
+
+## Sensitive areas
+
+Treat these as human-gated:
+
+- `.github/`
+- `scripts/github/`
+- `docs/AGENT_POLICY.md`
+- `docs/PIPELINE_SECURITY.md`
+- `docs/INCIDENT_RESPONSE.md`
+- `docs/RELEASE_POLICY.md`
+- `docs/RELEASE_CONTENTS.md`
+
+## Delivery boundaries
+
+- `rc` and `submission` approvals are always human decisions.
+- Release automation may package artifacts, but humans approve publication.
+- Never invent a workflow or secret change to "make CI pass."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blocus Focus Pokus
 
-Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 extends the same engine to Duo through mode configuration. Phase 3 adds structured issue intake, PR intelligence, and bounded branch-level agent repair. Phase 4 adds release-candidate packaging and protected-environment delivery gates.
+Plain-Python Blokus project repository for course delivery. Phase 1 targets Classic as a stable baseline. Phase 2 extends the same engine to Duo through mode configuration. Phase 3 adds structured issue intake, PR intelligence, and bounded branch-level agent repair. Phase 4 adds release-candidate packaging and protected-environment delivery gates. Phase 5 hardens the pipeline with tighter workflow security, provenance, and governance review.
 
 ## Project purpose
 
@@ -15,6 +15,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - Phase 2 direction: Duo mode by configuration in the same engine (`ModeConfig` extension + tests/fixtures), not by a separate engine.
 - Phase 3 direction: structured issue forms, label-driven agent entry, PR review intelligence, and bounded autonomous repair on `agent/*` branches.
 - Phase 4 direction: automated release-candidate packaging, evidence bundles, GitHub pre-releases, and protected `rc` / `submission` approval gates.
+- Phase 5 direction: workflow permission hardening, security review, artifact provenance, and operating guidance for the autonomous pipeline.
 
 ## Repository structure
 
@@ -41,6 +42,7 @@ Plain-Python Blokus project repository for course delivery. Phase 1 targets Clas
 - Team/report snapshot: `TEAM_SUMMARY.md`.
 - Phase 1 governance setup: `docs/phase1-governance.md`.
 - Phase 3 policy and autonomy boundary: `docs/AGENT_POLICY.md`.
+- Team GitHub CI/CD guide: `docs/GITHUB_CICD_GUIDE.md`.
 - Release contents and policy: `docs/RELEASE_CONTENTS.md`, `docs/RELEASE_POLICY.md`.
 - Evidence: `docs/evidence-log.md`.
 - AI usage disclosure: `docs/ai-usage.md`.

--- a/docs/GITHUB_CICD_GUIDE.md
+++ b/docs/GITHUB_CICD_GUIDE.md
@@ -93,6 +93,17 @@ Important consequences:
 - new third-party GitHub Actions should not be introduced casually
 - default `GITHUB_TOKEN` permissions are read-only unless a workflow job explicitly asks for more
 
+## What agents read
+
+The repository now includes explicit guidance files for GitHub Copilot and repository agents:
+
+- `.github/copilot-instructions.md`: repo-wide coding and validation guidance
+- `AGENTS.md`: agent-specific operating rules and hard stops
+- `.github/instructions/workflows.instructions.md`: extra rules for workflow, policy, and release-boundary files
+- `.github/instructions/rules.instructions.md`: extra rules for engine, tests, fixtures, and schemas
+
+If you open a task for agent work, assume those files are part of the agent's working context.
+
 ## Agent workflow expectations
 
 Agent work is allowed only inside the documented branch and PR loop.

--- a/docs/GITHUB_CICD_GUIDE.md
+++ b/docs/GITHUB_CICD_GUIDE.md
@@ -1,0 +1,169 @@
+# GitHub CI/CD Guide
+
+This guide is the day-to-day operating manual for teammates working in this repository through GitHub. It reflects the live repository controls as of April 7, 2026.
+
+## Core rules
+
+- Never push directly to `main`.
+- Every change reaches `main` through a pull request.
+- Normal development follows the review gates. Admin bypass is not part of the normal development workflow.
+- Human branches should use `codex/...` or another descriptive feature branch. The `agent/*` prefix is reserved for autonomous branch work.
+- Treat `.github/`, secrets, branch protections, and environment settings as sensitive. Those changes need extra human review.
+
+## What GitHub enforces today
+
+- `main` requires a pull request.
+- `main` requires `1` human approval.
+- Code-owner review is required when the changed paths are owned in `.github/CODEOWNERS`.
+- Approvals are dismissed when new commits are pushed.
+- Conversation resolution is required before merge.
+- The required merge-gate checks on `main` are: `lint`, `test`, `cli-smoke`, `fixture-schema`, and `evaluate`.
+- Additional checks may run on top of the merge gate, including `analyze (python)` from CodeQL and `dependency-review` when dependency manifests change.
+
+## Start work
+
+1. Open an issue or pick an existing one.
+2. Use the structured issue forms when possible.
+3. If the task is suitable for agent work, make sure the issue is precise enough to become `agent-ready`.
+4. Create a branch from `main`.
+5. Keep the branch scoped to the issue.
+
+Good local commands before you push:
+
+- `./scripts/install.sh`
+- `./scripts/test.sh`
+- `./scripts/cli_smoke.sh`
+- `./scripts/validate_fixtures.sh`
+- `./scripts/evaluate.sh`
+
+## Open a pull request
+
+When you open a PR:
+
+- link the issue
+- fill in the PR template
+- explain assumptions clearly
+- call out dependency changes, schema changes, docs changes, or workflow changes explicitly
+- confirm that no secret material was introduced
+
+The repository will automatically add review guidance:
+
+- `pr-intelligence` posts a review summary comment
+- workflow-sensitive PRs get `workflow-sensitive`
+- sensitive PRs also get `needs-review`
+
+## How to read CI
+
+The main CI workflow runs these jobs:
+
+- `lint`: fast style and import checks
+- `test`: unit and integration tests
+- `cli-smoke`: command-line surface sanity check
+- `fixture-schema`: JSON fixture and schema validation
+- `evaluate`: fixture-backed evaluation harness
+
+If CI fails:
+
+1. Open the PR Checks tab.
+2. Look at the first failed job, not only the overall red X.
+3. Read the job logs.
+4. Download any uploaded failure artifacts if they exist.
+5. Fix the narrowest cause first.
+
+Failure artifacts currently use short retention windows:
+
+- CI debug artifacts: `14` days
+- governance-review artifacts: `30` days
+- release-candidate and submission artifacts: `90` days
+
+## Security and supply chain checks
+
+The repository now has these GitHub-side protections enabled:
+
+- secret scanning
+- push protection
+- vulnerability alerts
+- Dependabot security updates
+- CodeQL scanning
+
+Important consequences:
+
+- pushes that include detected secrets may be blocked
+- dependency changes are visible and reviewable
+- new third-party GitHub Actions should not be introduced casually
+- default `GITHUB_TOKEN` permissions are read-only unless a workflow job explicitly asks for more
+
+## Agent workflow expectations
+
+Agent work is allowed only inside the documented branch and PR loop.
+
+Use `docs/AGENT_POLICY.md` for the exact rules, but the short version is:
+
+- `agent-ready` means the issue is structured enough for bounded agent work
+- `needs-human-spec` means humans need to clarify the task before an agent should implement it
+- autonomous repair is limited and only applies on `agent/*` branches
+- workflow-sensitive changes stay human-gated
+
+If you are unsure whether a task belongs with an agent, default to human-led clarification first.
+
+## Merge process
+
+A normal merge to `main` should happen only when:
+
+- required checks are green
+- the right reviewer has approved
+- unresolved conversations are closed
+- the PR scope is still aligned with the linked issue
+
+Do not use admin bypass for normal feature, bug-fix, docs, or test work.
+
+## What happens after merge
+
+After a PR merges into `main`:
+
+1. the `release-candidate` workflow starts automatically
+2. the repository packages a release candidate
+3. release notes, evidence, and provenance are generated
+4. the workflow pauses at the protected `rc` environment
+5. after human approval, GitHub can publish the pre-release
+
+Final publication is separate:
+
+1. a human manually runs `promote-submission`
+2. the workflow pauses at the protected `submission` environment
+3. after approval, the final GitHub Release is published
+
+## Who approves what
+
+- Normal PR merge: at least one human reviewer, plus code-owner coverage where applicable
+- `rc`: one configured reviewer in the `rc` environment; self-review is blocked
+- `submission`: one configured reviewer in the `submission` environment; self-review is blocked
+
+Operationally, the PR author should not be the release approver.
+
+## When to stop and ask for help
+
+Stop and escalate when:
+
+- rules semantics are unclear
+- the task needs secrets, settings, or workflow-permission changes
+- CI is failing for a reason you cannot classify quickly
+- a repair loop keeps repeating without progress
+- release artifacts or provenance do not look right
+
+Use these docs when that happens:
+
+- `docs/AGENT_POLICY.md`
+- `docs/RELEASE_POLICY.md`
+- `docs/PIPELINE_SECURITY.md`
+- `docs/INCIDENT_RESPONSE.md`
+- `docs/AUTONOMY_SCORECARD.md`
+
+## Suggested team habit
+
+For each PR review, ask the same quick questions:
+
+- Does this PR match the issue?
+- Are the right tests updated?
+- Are any workflow or contract changes hidden in the diff?
+- Would I be comfortable approving the resulting release candidate if this merged today?


### PR DESCRIPTION
## Summary

Adds a teammate-facing guide for how to work with this repository's GitHub CI/CD flow.

- add `docs/GITHUB_CICD_GUIDE.md`
- link the guide from `README.md`
- document the live merge gates, CI checks, release flow, and when to escalate

## Why

The repository now has a fairly rich GitHub workflow surface: protected main, structured issue intake, bounded agent repair, release-candidate automation, protected environments, and Phase 5 security hardening. Teammates need one practical operating guide that explains how to use that system without reading every policy doc first.

## Validation

- docs-only change
- `git diff --check`

## Notes

The guide reflects the live repository settings after the Phase 5 merge on April 7, 2026, including the exact current required checks on `main`.
