### PR TITLE
[DO NOT MERGE] Cache occupied cells per player (dont accept yet)

### DIFF
--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -31,6 +31,7 @@ def new_game(
         remaining_pieces={player: set(PIECE_IDS) for player in config.players},
         controller_types=controller_types,
         controller_strategies=controller_strategies,
+        occupied_cells={player: set() for player in config.players},
     )
 
 
@@ -43,19 +44,30 @@ def board_in_bounds(state: GameState, x: int, y: int) -> bool:
 def get_occupied_cells(state: GameState, player: str | None = None) -> set[Coordinate]:
     """Collect occupied coordinates, optionally filtering to one player."""
 
+    if state.occupied_cells is None:
+        # Defensive fallback for manually-constructed states.
+        occupied: set[Coordinate] = set()
+        for y, row in enumerate(state.board):
+            for x, cell in enumerate(row):
+                if cell is None:
+                    continue
+                if player is None or cell == player:
+                    occupied.add((x, y))
+        return occupied
+
+    if player is not None:
+        return state.occupied_cells.get(player, set())
     occupied: set[Coordinate] = set()
-    for y, row in enumerate(state.board):
-        for x, cell in enumerate(row):
-            if cell is None:
-                continue
-            if player is None or cell == player:
-                occupied.add((x, y))
+    for cells in state.occupied_cells.values():
+        occupied.update(cells)
     return occupied
 
 
 def is_first_move(state: GameState, player: str) -> bool:
     """Return whether the player has not yet placed any piece."""
 
+    if state.occupied_cells is not None:
+        return not state.occupied_cells.get(player)
     return not any(cell == player for row in state.board for cell in row)
 
 
@@ -252,6 +264,8 @@ def apply_move(state: GameState, move: Move) -> GameState:
     # Materialize the piece on the cloned board before advancing turn metadata.
     for x, y in cells:
         new_state.board[y][x] = move.player
+    if new_state.occupied_cells is not None:
+        new_state.occupied_cells[move.player].update(cells)
     new_state.remaining_pieces[move.player].remove(move.piece)
     new_state.history.append(move)
     new_state.current_player_index = _next_player_index(new_state)
@@ -313,6 +327,9 @@ def compute_scores(state: GameState) -> dict[str, int]:
 
 
 def occupied_square_counts(state: GameState) -> dict[str, int]:
+    if state.occupied_cells is not None:
+        return {player: len(state.occupied_cells.get(player, set())) for player in state.players}
+
     counts = {player: 0 for player in state.players}
     for row in state.board:
         for cell in row:

--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -9,6 +9,21 @@ from blokus.pieces import PIECE_IDS
 Coordinate = tuple[int, int]
 
 
+def _build_occupied_cells(
+    board: list[list[str | None]],
+    players: tuple[str, ...],
+) -> dict[str, set[Coordinate]]:
+    occupied: dict[str, set[Coordinate]] = {player: set() for player in players}
+    for y, row in enumerate(board):
+        for x, cell in enumerate(row):
+            if cell is None:
+                continue
+            if cell not in occupied:
+                raise ValueError(f"Board contains unknown player token {cell!r}.")
+            occupied[cell].add((x, y))
+    return occupied
+
+
 @dataclass(frozen=True)
 class Move:
     """One attempted or completed piece placement."""
@@ -69,6 +84,16 @@ class GameState:
     finished: bool = False
     controller_types: dict[str, str] = field(default_factory=dict)
     controller_strategies: dict[str, str] = field(default_factory=dict)
+    # Cached occupied coordinates per player.
+    # This is derived state and is intentionally not serialized.
+    occupied_cells: dict[str, set[Coordinate]] | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.occupied_cells is None:
+            self.occupied_cells = _build_occupied_cells(self.board, self.players)
+            return
+        for player in self.players:
+            self.occupied_cells.setdefault(player, set())
 
     @property
     def board_size(self) -> int:
@@ -85,6 +110,10 @@ class GameState:
     def clone(self) -> "GameState":
         """Create a deep-enough copy for safe state transitions."""
 
+        occupied_cells = None
+        if self.occupied_cells is not None:
+            occupied_cells = {player: set(cells) for player, cells in self.occupied_cells.items()}
+
         return GameState(
             mode=self.mode,
             board=deepcopy(self.board),
@@ -97,6 +126,7 @@ class GameState:
             finished=self.finished,
             controller_types=dict(self.controller_types),
             controller_strategies=dict(self.controller_strategies),
+            occupied_cells=occupied_cells,
         )
 
     def to_dict(self) -> dict[str, object]:
@@ -193,6 +223,8 @@ class GameState:
             player: str(strategy_source.get(player, "default")) for player in players
         }
 
+        occupied_cells = _build_occupied_cells(board, players)
+
         return cls(
             mode=mode,
             board=board,
@@ -205,4 +237,5 @@ class GameState:
             finished=bool(data.get("finished", False)),
             controller_types=controllers,
             controller_strategies=strategies,
+            occupied_cells=occupied_cells,
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,6 +5,7 @@ from blokus.engine import (
     compute_scores,
     list_legal_moves,
     new_game,
+    occupied_square_counts,
     pass_turn,
     score_player,
     validate_move,
@@ -68,6 +69,8 @@ class EngineRuleTests(unittest.TestCase):
         self.assertEqual(len(next_state.history), 1)
         self.assertNotIn("I1", next_state.remaining_pieces["blue"])
         self.assertEqual(next_state.board[0][0], "blue")
+        self.assertIsNotNone(next_state.occupied_cells)
+        self.assertIn((0, 0), next_state.occupied_cells["blue"])
 
     def test_pass_requires_player_to_be_blocked(self) -> None:
         state = new_game()
@@ -154,6 +157,28 @@ class EngineRuleTests(unittest.TestCase):
         }
         self.assertEqual(len(moves), len(placements))
         self.assertTrue(all(validate_move(state, move).ok for move in moves))
+
+    def test_occupied_cache_tracks_board_state(self) -> None:
+        state = new_game()
+        self.assertIsNotNone(state.occupied_cells)
+        for player in state.players:
+            self.assertEqual(state.occupied_cells[player], set())
+
+        state = apply_move(state, Move("blue", "I1", 0, 0))
+        self.assertIn((0, 0), state.occupied_cells["blue"])
+        self.assertEqual(occupied_square_counts(state)["blue"], 1)
+
+        state = apply_move(state, Move("yellow", "I1", 19, 0))
+        self.assertIn((19, 0), state.occupied_cells["yellow"])
+        self.assertEqual(
+            occupied_square_counts(state),
+            {
+                "blue": 1,
+                "yellow": 1,
+                "red": 0,
+                "green": 0,
+            },
+        )
 
     def test_list_legal_moves_respects_zero_limit(self) -> None:
         state = new_game()


### PR DESCRIPTION
## Status\nDO NOT MERGE / DO NOT ACCEPT YET. This is a draft PR for early visibility only.\n\n## Summary\n- Add per-player occupied cell cache to GameState (derived, not serialized).\n- Update engine hot paths to use cache instead of scanning the board.\n- Update apply_move to maintain cache; add tests to verify cache correctness.\n\n## Testing\n- ./scripts/test.sh