### PR TITLE
Initialize occupied-cells cache field

### DIFF
--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -23,6 +23,7 @@ def new_game(
     controller_strategies = {
         player: (strategies or {}).get(player, "default") for player in config.players
     }
+    occupied_cells_by_player = {player: set() for player in config.players}
     return GameState(
         mode=mode,
         board=board,
@@ -31,6 +32,7 @@ def new_game(
         remaining_pieces={player: set(PIECE_IDS) for player in config.players},
         controller_types=controller_types,
         controller_strategies=controller_strategies,
+        occupied_cells_by_player=occupied_cells_by_player,
     )
 
 

--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -23,7 +23,9 @@ def new_game(
     controller_strategies = {
         player: (strategies or {}).get(player, "default") for player in config.players
     }
-    occupied_cells_by_player = {player: set() for player in config.players}
+    occupied_cells_by_player: dict[str, set[Coordinate]] = {
+        player: set[Coordinate]() for player in config.players
+    }
     return GameState(
         mode=mode,
         board=board,

--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -23,9 +23,7 @@ def new_game(
     controller_strategies = {
         player: (strategies or {}).get(player, "default") for player in config.players
     }
-    occupied_cells_by_player: dict[str, set[Coordinate]] = {
-        player: set[Coordinate]() for player in config.players
-    }
+    occupied_cells_by_player: dict[str, set[Coordinate]] = {player: set() for player in config.players}
     return GameState(
         mode=mode,
         board=board,

--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -76,7 +76,7 @@ class GameState:
     def __post_init__(self) -> None:
         # Ensure every configured player has a cache entry.
         for player in self.players:
-            self.occupied_cells_by_player.setdefault(player, set[Coordinate]())
+            self.occupied_cells_by_player.setdefault(player, set())
 
     @property
     def board_size(self) -> int:
@@ -105,6 +105,8 @@ class GameState:
             finished=self.finished,
             controller_types=dict(self.controller_types),
             controller_strategies=dict(self.controller_strategies),
+            # Derived cache is deep-copied for correctness in atomic step 1.
+            # Performance tradeoffs will be evaluated in a later atomic step.
             occupied_cells_by_player={
                 player: set(cells) for player, cells in self.occupied_cells_by_player.items()
             },

--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -76,7 +76,7 @@ class GameState:
     def __post_init__(self) -> None:
         # Ensure every configured player has a cache entry.
         for player in self.players:
-            self.occupied_cells_by_player.setdefault(player, set())
+            self.occupied_cells_by_player.setdefault(player, set[Coordinate]())
 
     @property
     def board_size(self) -> int:

--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -69,6 +69,14 @@ class GameState:
     finished: bool = False
     controller_types: dict[str, str] = field(default_factory=dict)
     controller_strategies: dict[str, str] = field(default_factory=dict)
+    # Cached occupied coordinates per player.
+    # This is derived state and is intentionally not serialized.
+    occupied_cells_by_player: dict[str, set[Coordinate]] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        # Ensure every configured player has a cache entry.
+        for player in self.players:
+            self.occupied_cells_by_player.setdefault(player, set())
 
     @property
     def board_size(self) -> int:
@@ -97,6 +105,9 @@ class GameState:
             finished=self.finished,
             controller_types=dict(self.controller_types),
             controller_strategies=dict(self.controller_strategies),
+            occupied_cells_by_player={
+                player: set(cells) for player, cells in self.occupied_cells_by_player.items()
+            },
         )
 
     def to_dict(self) -> dict[str, object]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,7 +11,7 @@ from blokus.engine import (
     validate_pass,
 )
 from blokus.models import Move
-from blokus.pieces import absolute_cells
+from blokus.pieces import PIECE_IDS, absolute_cells
 
 
 def play_standard_opening_cycle():
@@ -49,6 +49,21 @@ class EngineRuleTests(unittest.TestCase):
         result = validate_move(state, Move("yellow", "I1", 19, 0))
         self.assertFalse(result.ok)
         self.assertIn("It is blue's turn", result.reason)
+
+    def test_new_game_initializes_occupied_cells_by_player_cache(self) -> None:
+        state = new_game()
+
+        self.assertEqual(set(state.occupied_cells_by_player.keys()), set(state.players))
+        for player in state.players:
+            self.assertEqual(state.occupied_cells_by_player[player], set())
+
+        # Board remains empty.
+        self.assertTrue(all(cell is None for row in state.board for cell in row))
+
+        # Existing initialization behavior remains intact.
+        self.assertEqual(set(state.remaining_pieces.keys()), set(state.players))
+        for player in state.players:
+            self.assertEqual(state.remaining_pieces[player], set(PIECE_IDS))
 
     def test_same_color_edge_contact_is_illegal(self) -> None:
         state = play_standard_opening_cycle()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -60,6 +60,17 @@ class EngineRuleTests(unittest.TestCase):
         # Board remains empty.
         self.assertTrue(all(cell is None for row in state.board for cell in row))
 
+        # Per-player cache entries must be distinct and independent.
+        state.occupied_cells_by_player["blue"].add((0, 0))
+        for player in state.players:
+            if player == "blue":
+                continue
+            self.assertEqual(state.occupied_cells_by_player[player], set())
+            self.assertIsNot(
+                state.occupied_cells_by_player["blue"],
+                state.occupied_cells_by_player[player],
+            )
+
         # Existing initialization behavior remains intact.
         self.assertEqual(set(state.remaining_pieces.keys()), set(state.players))
         for player in state.players:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -65,6 +65,20 @@ class EngineRuleTests(unittest.TestCase):
         for player in state.players:
             self.assertEqual(state.remaining_pieces[player], set(PIECE_IDS))
 
+    def test_clone_deep_copies_occupied_cells_by_player_sets(self) -> None:
+        state = new_game()
+        state.occupied_cells_by_player["blue"].add((0, 0))
+
+        cloned = state.clone()
+        self.assertIsNot(
+            state.occupied_cells_by_player["blue"],
+            cloned.occupied_cells_by_player["blue"],
+        )
+
+        cloned.occupied_cells_by_player["blue"].add((1, 1))
+        self.assertEqual(state.occupied_cells_by_player["blue"], {(0, 0)})
+        self.assertEqual(cloned.occupied_cells_by_player["blue"], {(0, 0), (1, 1)})
+
     def test_same_color_edge_contact_is_illegal(self) -> None:
         state = play_standard_opening_cycle()
         result = validate_move(state, Move("blue", "I2", 1, 0))

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -22,6 +22,15 @@ class SerializationTests(unittest.TestCase):
         state = GameState.from_dict(payload)
         self.assertEqual(state.to_dict(), payload)
 
+    def test_state_to_dict_excludes_occupied_cells_by_player(self) -> None:
+        state = new_game()
+        payload = state.to_dict()
+        self.assertNotIn("occupied_cells_by_player", payload)
+
+        # Deserialization should not require derived cache fields.
+        reloaded = GameState.from_dict(payload)
+        self.assertEqual(set(reloaded.occupied_cells_by_player.keys()), set(reloaded.players))
+
     def test_state_round_trip_after_moves(self) -> None:
         state = new_game(
             controllers={"blue": "computer", "yellow": "human", "red": "human", "green": "human"},


### PR DESCRIPTION
## Summary
- Add `GameState.occupied_cells_by_player: dict[str, set[Coordinate]]` as derived (non-serialized) state.
- Initialize the cache in `new_game()` with one empty `set()` per configured player.
- Add a minimal unit test asserting cache shape + existing initialization invariants (board empty, `remaining_pieces` intact).

## Notes
- This PR intentionally does *not* update rule logic (`apply_move`, `get_occupied_cells`, etc.). It only introduces and initializes the data structure (atomic step 1).

## Testing
- `./scripts/test.sh`