### PR TITLE
Atomic Step 2: update occupied-cell cache on apply_move

### DIFF
--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -245,11 +245,13 @@ def apply_move(state: GameState, move: Move) -> GameState:
         raise ValueError(result.reason)
 
     new_state = state.clone()
-    cells = absolute_cells(
-        move.piece,
-        origin=(move.x, move.y),
-        rotation=move.rotation,
-        flipped=move.flipped,
+    cells = tuple(
+        absolute_cells(
+            move.piece,
+            origin=(move.x, move.y),
+            rotation=move.rotation,
+            flipped=move.flipped,
+        )
     )
     # Materialize the piece on the cloned board before advancing turn metadata.
     for x, y in cells:

--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -254,6 +254,8 @@ def apply_move(state: GameState, move: Move) -> GameState:
     # Materialize the piece on the cloned board before advancing turn metadata.
     for x, y in cells:
         new_state.board[y][x] = move.player
+    # Keep the derived occupied-cells cache consistent with the cloned board.
+    new_state.occupied_cells_by_player[move.player].update(cells)
     new_state.remaining_pieces[move.player].remove(move.piece)
     new_state.history.append(move)
     new_state.current_player_index = _next_player_index(new_state)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -115,21 +115,16 @@ class EngineRuleTests(unittest.TestCase):
 
         next_state = apply_move(state, move)
 
-        expected_cells = set(
-            absolute_cells(
-                move.piece,
-                origin=(move.x, move.y),
-                rotation=move.rotation,
-                flipped=move.flipped,
-            )
-        )
-        self.assertEqual(next_state.occupied_cells_by_player["blue"], expected_cells)
+        board_cells = {
+            (x, y)
+            for y, row in enumerate(next_state.board)
+            for x, cell in enumerate(row)
+            if cell == "blue"
+        }
+        self.assertEqual(next_state.occupied_cells_by_player["blue"], board_cells)
 
         # Existing board behavior still matches the applied move.
-        for x, y in expected_cells:
-            self.assertEqual(next_state.board[y][x], "blue")
-        occupied_count = sum(1 for row in next_state.board for cell in row if cell is not None)
-        self.assertEqual(occupied_count, len(expected_cells))
+        self.assertEqual(board_cells, {(0, 0), (1, 0)})
 
     def test_apply_move_does_not_mutate_original_state_cache(self) -> None:
         state = new_game()
@@ -164,6 +159,19 @@ class EngineRuleTests(unittest.TestCase):
 
         self.assertEqual(state.board, before_board)
         self.assertEqual(state.occupied_cells_by_player, before_cache)
+
+    def test_occupied_cells_cache_accumulates_and_matches_board_per_player(self) -> None:
+        state = play_standard_opening_cycle()
+        state = apply_move(state, Move("blue", "I2", 1, 1))
+
+        for player in state.players:
+            board_cells = {
+                (x, y)
+                for y, row in enumerate(state.board)
+                for x, cell in enumerate(row)
+                if cell == player
+            }
+            self.assertEqual(state.occupied_cells_by_player[player], board_cells)
 
     def test_pass_requires_player_to_be_blocked(self) -> None:
         state = new_game()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -109,6 +109,62 @@ class EngineRuleTests(unittest.TestCase):
         self.assertNotIn("I1", next_state.remaining_pieces["blue"])
         self.assertEqual(next_state.board[0][0], "blue")
 
+    def test_apply_move_adds_placed_cells_to_occupied_cells_cache(self) -> None:
+        state = new_game()
+        move = Move("blue", "I2", 0, 0)
+
+        next_state = apply_move(state, move)
+
+        expected_cells = set(
+            absolute_cells(
+                move.piece,
+                origin=(move.x, move.y),
+                rotation=move.rotation,
+                flipped=move.flipped,
+            )
+        )
+        self.assertEqual(next_state.occupied_cells_by_player["blue"], expected_cells)
+
+        # Existing board behavior still matches the applied move.
+        for x, y in expected_cells:
+            self.assertEqual(next_state.board[y][x], "blue")
+        occupied_count = sum(1 for row in next_state.board for cell in row if cell is not None)
+        self.assertEqual(occupied_count, len(expected_cells))
+
+    def test_apply_move_does_not_mutate_original_state_cache(self) -> None:
+        state = new_game()
+        move = Move("blue", "I2", 0, 0)
+
+        _ = apply_move(state, move)
+
+        # Original state remains unchanged.
+        self.assertEqual(state.occupied_cells_by_player["blue"], set())
+        self.assertTrue(all(cell is None for row in state.board for cell in row))
+
+    def test_apply_move_does_not_update_other_players_cache_sets(self) -> None:
+        state = new_game()
+        move = Move("blue", "I2", 0, 0)
+
+        next_state = apply_move(state, move)
+
+        for player in next_state.players:
+            if player == "blue":
+                continue
+            self.assertEqual(next_state.occupied_cells_by_player[player], set())
+
+    def test_apply_move_illegal_move_raises_and_does_not_mutate_board_or_cache(self) -> None:
+        state = new_game()
+        # Add a sentinel to ensure we detect cache mutation (cache is derived and not serialized).
+        state.occupied_cells_by_player["blue"].add((5, 5))
+        before_board = [row[:] for row in state.board]
+        before_cache = {player: set(cells) for player, cells in state.occupied_cells_by_player.items()}
+
+        with self.assertRaisesRegex(ValueError, "must cover start corner"):
+            apply_move(state, Move("blue", "I1", 1, 1))
+
+        self.assertEqual(state.board, before_board)
+        self.assertEqual(state.occupied_cells_by_player, before_cache)
+
     def test_pass_requires_player_to_be_blocked(self) -> None:
         state = new_game()
         with self.assertRaisesRegex(ValueError, "only pass when no legal move exists"):


### PR DESCRIPTION
## Summary
- Update `apply_move` to keep `occupied_cells_by_player` consistent with the cloned board after a legal placement.
- Add focused unit tests verifying cache updates for the moving player, no mutation of the input state, and no cache updates on illegal moves.

## Scope
- Atomic Step 2 only: write-path cache maintenance on legal `apply_move` calls.
- No read-path refactors (e.g., `get_occupied_cells`, touch checks, anchors) and no rule/validation changes.

## Testing
- `./scripts/test.sh`