### PR TITLE
Use occupied-cells cache for read helpers

### DIFF
--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -45,20 +45,20 @@ def board_in_bounds(state: GameState, x: int, y: int) -> bool:
 def get_occupied_cells(state: GameState, player: str | None = None) -> set[Coordinate]:
     """Collect occupied coordinates, optionally filtering to one player."""
 
-    occupied: set[Coordinate] = set()
-    for y, row in enumerate(state.board):
-        for x, cell in enumerate(row):
-            if cell is None:
-                continue
-            if player is None or cell == player:
-                occupied.add((x, y))
-    return occupied
+    # Read from the derived cache, but always return defensive copies so callers
+    # cannot mutate internal state.
+    if player is None:
+        occupied: set[Coordinate] = set()
+        for cells in state.occupied_cells_by_player.values():
+            occupied.update(cells)
+        return occupied
+    return set(state.occupied_cells_by_player.get(player, set()))
 
 
 def is_first_move(state: GameState, player: str) -> bool:
     """Return whether the player has not yet placed any piece."""
 
-    return not any(cell == player for row in state.board for cell in row)
+    return not state.occupied_cells_by_player.get(player, set())
 
 
 def _has_edge_contact_with_player(state: GameState, player: str, cells: tuple[Coordinate, ...]) -> bool:
@@ -319,9 +319,7 @@ def compute_scores(state: GameState) -> dict[str, int]:
 
 
 def occupied_square_counts(state: GameState) -> dict[str, int]:
-    counts = {player: 0 for player in state.players}
-    for row in state.board:
-        for cell in row:
-            if cell is not None:
-                counts[cell] += 1
-    return counts
+    return {
+        player: len(state.occupied_cells_by_player.get(player, set()))
+        for player in state.players
+    }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,8 +3,11 @@ import unittest
 from blokus.engine import (
     apply_move,
     compute_scores,
+    get_occupied_cells,
+    is_first_move,
     list_legal_moves,
     new_game,
+    occupied_square_counts,
     pass_turn,
     score_player,
     validate_move,
@@ -109,6 +112,76 @@ class EngineRuleTests(unittest.TestCase):
         self.assertNotIn("I1", next_state.remaining_pieces["blue"])
         self.assertEqual(next_state.board[0][0], "blue")
 
+    def test_get_occupied_cells_returns_player_cache_after_legal_move(self) -> None:
+        state = new_game()
+        state = apply_move(state, Move("blue", "I2", 0, 0))
+
+        expected_blue = {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell == "blue"
+        }
+        self.assertEqual(state.occupied_cells_by_player["blue"], expected_blue)
+        self.assertEqual(get_occupied_cells(state, "blue"), expected_blue)
+
+    def test_get_occupied_cells_returns_union_across_players(self) -> None:
+        state = play_standard_opening_cycle()
+
+        expected_all = {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell is not None
+        }
+        self.assertEqual(get_occupied_cells(state), expected_all)
+
+    def test_get_occupied_cells_returns_defensive_copy(self) -> None:
+        state = new_game()
+        state = apply_move(state, Move("blue", "I2", 0, 0))
+
+        returned = get_occupied_cells(state, "blue")
+        self.assertEqual(returned, state.occupied_cells_by_player["blue"])
+
+        # Mutating the returned set must not mutate the internal cache.
+        returned.add((5, 5))
+        returned.discard(next(iter(state.occupied_cells_by_player["blue"])))
+        self.assertNotIn((5, 5), state.occupied_cells_by_player["blue"])
+        self.assertEqual(
+            state.occupied_cells_by_player["blue"],
+            {
+                (x, y)
+                for y, row in enumerate(state.board)
+                for x, cell in enumerate(row)
+                if cell == "blue"
+            },
+        )
+
+    def test_is_first_move_reflects_player_occupancy(self) -> None:
+        state = new_game()
+        self.assertTrue(is_first_move(state, "blue"))
+
+        state = apply_move(state, Move("blue", "I2", 0, 0))
+        self.assertFalse(is_first_move(state, "blue"))
+        self.assertTrue(is_first_move(state, "yellow"))
+
+    def test_occupied_square_counts_matches_board_after_moves(self) -> None:
+        state = play_standard_opening_cycle()
+        state = apply_move(state, Move("blue", "I2", 1, 1))
+
+        expected_counts = {player: 0 for player in state.players}
+        for row in state.board:
+            for cell in row:
+                if cell is not None:
+                    expected_counts[cell] += 1
+
+        self.assertEqual(occupied_square_counts(state), expected_counts)
+
+    def test_cache_read_functions_preserve_unknown_player_behavior(self) -> None:
+        state = new_game()
+        self.assertEqual(get_occupied_cells(state, "orange"), set())
+        self.assertTrue(is_first_move(state, "orange"))
+
     def test_apply_move_adds_placed_cells_to_occupied_cells_cache(self) -> None:
         state = new_game()
         move = Move("blue", "I2", 0, 0)
@@ -150,7 +223,8 @@ class EngineRuleTests(unittest.TestCase):
     def test_apply_move_illegal_move_raises_and_does_not_mutate_board_or_cache(self) -> None:
         state = new_game()
         # Add a sentinel to ensure we detect cache mutation (cache is derived and not serialized).
-        state.occupied_cells_by_player["blue"].add((5, 5))
+        # Use a non-active player so first-move logic for the mover stays intact.
+        state.occupied_cells_by_player["yellow"].add((5, 5))
         before_board = [row[:] for row in state.board]
         before_cache = {player: set(cells) for player, cells in state.occupied_cells_by_player.items()}
 


### PR DESCRIPTION
## Summary
- Refactors `get_occupied_cells`, `is_first_move`, and `occupied_square_counts` to read from `GameState.occupied_cells_by_player` instead of scanning the board.
- Returns defensive copies from `get_occupied_cells` so callers cannot mutate the internal cache.
- Adds focused unit tests that validate cache-backed behavior while deriving expected occupied cells by scanning `state.board`.

## Why This Step Is Limited
This change is intentionally scoped to cache *reads* only; it relies on the already-merged cache maintenance in `apply_move` and avoids touching move validation, move generation, serialization, or any cache rebuild logic.

## Testing
- `./scripts/test.sh`