### PR TITLE
Refactor anchor helpers to reuse occupied-cell cache

### DIFF
--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -179,7 +179,8 @@ def _anchor_cells(state: GameState, player: str) -> set[Coordinate]:
                 continue
             if state.board[ay][ax] is not None:
                 continue
-            if _has_edge_contact_with_player(state, player, (anchor,)):
+            # Avoid re-reading the occupied-cell cache for every candidate anchor.
+            if any((ax + odx, ay + ody) in occupied for odx, ody in ORTHOGONAL_DELTAS):
                 continue
             anchors.add(anchor)
     return anchors

--- a/src/blokus/engine.py
+++ b/src/blokus/engine.py
@@ -168,9 +168,10 @@ def _anchor_cells(state: GameState, player: str) -> set[Coordinate]:
     if is_first_move(state, player):
         return {state.start_corners[player]}
 
-    occupied = get_occupied_cells(state, player)
+    # Only same-color occupancy matters for anchor eligibility.
+    occupied_same_color = get_occupied_cells(state, player)
     anchors: set[Coordinate] = set()
-    for x, y in occupied:
+    for x, y in occupied_same_color:
         for dx, dy in DIAGONAL_DELTAS:
             anchor = (x + dx, y + dy)
             ax, ay = anchor
@@ -180,7 +181,11 @@ def _anchor_cells(state: GameState, player: str) -> set[Coordinate]:
             if state.board[ay][ax] is not None:
                 continue
             # Avoid re-reading the occupied-cell cache for every candidate anchor.
-            if any((ax + odx, ay + ody) in occupied for odx, ody in ORTHOGONAL_DELTAS):
+            # Opponent orthogonal adjacency is allowed in Blokus; only same-color edge contact is illegal.
+            if any(
+                (ax + odx, ay + ody) in occupied_same_color
+                for odx, ody in ORTHOGONAL_DELTAS
+            ):
                 continue
             anchors.add(anchor)
     return anchors

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 import unittest
 
 from blokus.engine import (
+    _anchor_cells,
     apply_move,
     compute_scores,
     get_occupied_cells,
@@ -103,6 +104,36 @@ class EngineRuleTests(unittest.TestCase):
         state = play_standard_opening_cycle()
         result = validate_move(state, Move("blue", "I2", 1, 1))
         self.assertTrue(result.ok)
+
+    def test_non_opening_move_requires_same_color_corner_contact(self) -> None:
+        state = play_standard_opening_cycle()
+
+        # Far from blue's starting piece: no edge contact and no diagonal contact.
+        result = validate_move(state, Move("blue", "I2", 5, 5))
+        self.assertFalse(result.ok)
+        self.assertIn("touch at least one same-color piece at a corner", result.reason)
+
+    def test_anchor_cells_are_empty_and_in_bounds(self) -> None:
+        state = play_standard_opening_cycle()
+
+        anchors = _anchor_cells(state, "blue")
+        occupied_all = {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell is not None
+        }
+        self.assertTrue(anchors.isdisjoint(occupied_all))
+        self.assertTrue(
+            all(0 <= x < state.board_size and 0 <= y < state.board_size for x, y in anchors)
+        )
+
+    def test_list_legal_moves_returns_valid_moves_after_opening(self) -> None:
+        state = play_standard_opening_cycle()
+
+        moves = list_legal_moves(state, limit=50)
+        self.assertTrue(moves)
+        self.assertTrue(all(validate_move(state, move).ok for move in moves))
 
     def test_apply_move_updates_turn_history_and_piece_pool(self) -> None:
         state = new_game()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -113,20 +113,47 @@ class EngineRuleTests(unittest.TestCase):
         self.assertFalse(result.ok)
         self.assertIn("touch at least one same-color piece at a corner", result.reason)
 
-    def test_anchor_cells_are_empty_and_in_bounds(self) -> None:
+    def test_anchor_cells_are_empty_in_bounds_and_avoid_same_color_edge_contact(self) -> None:
         state = play_standard_opening_cycle()
 
         anchors = _anchor_cells(state, "blue")
+        orthogonal = ((1, 0), (-1, 0), (0, 1), (0, -1))
         occupied_all = {
             (x, y)
             for y, row in enumerate(state.board)
             for x, cell in enumerate(row)
             if cell is not None
         }
+        occupied_blue = {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell == "blue"
+        }
         self.assertTrue(anchors.isdisjoint(occupied_all))
         self.assertTrue(
             all(0 <= x < state.board_size and 0 <= y < state.board_size for x, y in anchors)
         )
+        self.assertTrue(
+            all(
+                all((ax + dx, ay + dy) not in occupied_blue for dx, dy in orthogonal)
+                for ax, ay in anchors
+            )
+        )
+
+    def test_anchor_cells_allow_opponent_orthogonal_adjacency(self) -> None:
+        state = play_standard_opening_cycle()
+
+        # (1, 1) is a natural blue anchor (diagonal from blue's opening at (0, 0)).
+        expected_anchor = (1, 1)
+
+        # Place an opponent square orthogonally adjacent to that anchor.
+        # This must not disqualify the anchor because only same-color edge contact is illegal.
+        state.board[0][1] = "yellow"
+        state.occupied_cells_by_player["yellow"].add((1, 0))
+
+        anchors = _anchor_cells(state, "blue")
+        self.assertIn(expected_anchor, anchors)
 
     def test_list_legal_moves_returns_valid_moves_after_opening(self) -> None:
         state = play_standard_opening_cycle()


### PR DESCRIPTION
## Summary
- Reuse the cache-backed occupied set when generating anchors to avoid repeated defensive copies.
- Add focused rule/anchor tests to ensure move validation and move generation are unchanged.

## Testing
- ./scripts/test.sh

## Scope Notes
- Change is intentionally limited to cache-read behavior in the same-color contact / anchor helper step; opening/edge/corner semantics are unchanged.