### PR TITLE
Rebuild occupied-cell cache on deserialization

### DIFF
--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -167,6 +167,14 @@ class GameState:
                     parsed_row.append(player_for_symbol(symbol))
             board.append(parsed_row)
 
+        # Rebuild derived occupied-cells cache from the parsed board.
+        occupied_cells_by_player: dict[str, set[Coordinate]] = {player: set() for player in players}
+        for y, row in enumerate(board):
+            for x, cell in enumerate(row):
+                if cell is None:
+                    continue
+                occupied_cells_by_player[cell].add((x, y))
+
         remaining_source = data.get("remaining_pieces")
         if not isinstance(remaining_source, dict):
             raise ValueError("State is missing 'remaining_pieces'.")
@@ -218,4 +226,5 @@ class GameState:
             finished=bool(data.get("finished", False)),
             controller_types=controllers,
             controller_strategies=strategies,
+            occupied_cells_by_player=occupied_cells_by_player,
         )

--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -173,6 +173,10 @@ class GameState:
             for x, cell in enumerate(row):
                 if cell is None:
                     continue
+                if cell not in occupied_cells_by_player:
+                    raise ValueError(
+                        f"Board contains player '{cell}' not present in players {players!r}."
+                    )
                 occupied_cells_by_player[cell].add((x, y))
 
         remaining_source = data.get("remaining_pieces")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -37,6 +37,27 @@ def blocked_blue_state():
     return state
 
 
+def board_occupied_cells(state):
+    """Derive occupied cells by scanning the board (not cache-backed helpers)."""
+
+    expected_all = {
+        (x, y)
+        for y, row in enumerate(state.board)
+        for x, cell in enumerate(row)
+        if cell is not None
+    }
+    expected_by_player = {
+        player: {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell == player
+        }
+        for player in state.players
+    }
+    return expected_all, expected_by_player
+
+
 class EngineRuleTests(unittest.TestCase):
     def test_unsupported_duo_mode_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "Unsupported mode 'duo'"):
@@ -93,6 +114,25 @@ class EngineRuleTests(unittest.TestCase):
         cloned.occupied_cells_by_player["blue"].add((1, 1))
         self.assertEqual(state.occupied_cells_by_player["blue"], {(0, 0)})
         self.assertEqual(cloned.occupied_cells_by_player["blue"], {(0, 0), (1, 1)})
+
+    def test_clone_preserves_cache_contents_without_sharing_sets_after_moves(self) -> None:
+        state = play_standard_opening_cycle()
+        state = apply_move(state, Move("blue", "I2", 1, 1))
+
+        cloned = state.clone()
+        for player in state.players:
+            self.assertEqual(
+                cloned.occupied_cells_by_player[player],
+                state.occupied_cells_by_player[player],
+            )
+            self.assertIsNot(
+                cloned.occupied_cells_by_player[player],
+                state.occupied_cells_by_player[player],
+            )
+
+        # Mutating the clone must not affect the original.
+        cloned.occupied_cells_by_player["blue"].add((2, 2))
+        self.assertNotIn((2, 2), state.occupied_cells_by_player["blue"])
 
     def test_same_color_edge_contact_is_illegal(self) -> None:
         state = play_standard_opening_cycle()
@@ -193,6 +233,15 @@ class EngineRuleTests(unittest.TestCase):
             if cell is not None
         }
         self.assertEqual(get_occupied_cells(state), expected_all)
+
+    def test_get_occupied_cells_matches_board_scan_per_player_after_multiple_moves(self) -> None:
+        state = play_standard_opening_cycle()
+        # Extend beyond the opening cycle to cover incremental cache updates.
+        state = apply_move(state, Move("blue", "I2", 1, 1))
+
+        _expected_all, expected_by_player = board_occupied_cells(state)
+        for player in state.players:
+            self.assertEqual(get_occupied_cells(state, player), expected_by_player[player])
 
     def test_get_occupied_cells_returns_defensive_copy(self) -> None:
         state = new_game()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,12 +3,33 @@ from pathlib import Path
 from typing import cast
 import unittest
 
-from blokus.engine import apply_move, new_game
+from blokus.engine import apply_move, get_occupied_cells, new_game
 from blokus.models import GameState, Move
 from blokus.review.types import Finding, ReviewPayload, ReviewResult, ReviewSummary, UncertainRisk
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def board_occupied_cells(state: GameState):
+    """Derive occupied cells by scanning the board (not cache-backed helpers)."""
+
+    expected_all = {
+        (x, y)
+        for y, row in enumerate(state.board)
+        for x, cell in enumerate(row)
+        if cell is not None
+    }
+    expected_by_player = {
+        player: {
+            (x, y)
+            for y, row in enumerate(state.board)
+            for x, cell in enumerate(row)
+            if cell == player
+        }
+        for player in state.players
+    }
+    return expected_all, expected_by_player
 
 
 class SerializationTests(unittest.TestCase):
@@ -48,6 +69,26 @@ class SerializationTests(unittest.TestCase):
         self.assertEqual(reloaded.to_dict(), state.to_dict())
         self.assertEqual(reloaded.controller_types["blue"], "computer")
         self.assertEqual(reloaded.controller_strategies["blue"], "default")
+
+    def test_round_tripped_state_rebuilds_occupied_cells_cache_from_board(self) -> None:
+        state = new_game()
+        for move in (
+            Move("blue", "I1", 0, 0),
+            Move("yellow", "I1", 19, 0),
+            Move("red", "I1", 19, 19),
+            Move("green", "I1", 0, 19),
+            Move("blue", "I2", 1, 1),
+        ):
+            state = apply_move(state, move)
+
+        reloaded = GameState.from_dict(state.to_dict())
+        expected_all, expected_by_player = board_occupied_cells(reloaded)
+
+        for player in reloaded.players:
+            self.assertEqual(reloaded.occupied_cells_by_player[player], expected_by_player[player])
+            self.assertEqual(get_occupied_cells(reloaded, player), expected_by_player[player])
+
+        self.assertEqual(get_occupied_cells(reloaded), expected_all)
 
     def test_invalid_board_symbol_is_rejected(self) -> None:
         payload = self.load_initial_payload()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -97,6 +97,16 @@ class SerializationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "No player configured for board symbol"):
             GameState.from_dict(payload)
 
+    def test_board_player_missing_from_players_is_rejected(self) -> None:
+        payload = self.load_initial_payload()
+
+        # 'O' maps to player 'orange' which is not in classic mode's player list.
+        board = cast(list[str], payload["board"])
+        board[0] = "O" + board[0][1:]
+
+        with self.assertRaisesRegex(ValueError, "Board contains player 'orange'"):
+            GameState.from_dict(payload)
+
     def test_mismatched_player_list_is_rejected(self) -> None:
         payload = self.load_initial_payload()
         payload["players"] = ["blue", "yellow"]


### PR DESCRIPTION
## Summary
- Add regression tests that derive occupied cells by scanning `state.board` and assert the occupied-cell cache stays consistent across normal play, cloning, and serialization round-trips.
- Fix `GameState.from_dict()` to rebuild `occupied_cells_by_player` from the parsed board so deserialized states are immediately usable by cache-backed helpers.

## Testing
- `./scripts/test.sh`