### PR TITLE
[codex] Add maintainer docstrings for review workflow

### DIFF
--- a/scripts/github/agentic_code_review.py
+++ b/scripts/github/agentic_code_review.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Run agentic pull-request review and publish its artifacts."""
+"""Run the agentic pull-request review workflow from the command line.
+
+This script is the entry point for producing agentic review artifacts in JSON
+and Markdown form. It prepares repository imports, loads review configuration,
+resolves optional GitHub event/ref inputs, runs ReviewCoordinator, and writes
+the resulting artifacts to configured output paths. When same-repo PR metadata
+and GitHub credentials are available, it also posts or updates a pull-request
+comment with the rendered review. The process prints the Markdown review and
+uses the review verdict to choose its exit code.
+"""
 
 from __future__ import annotations
 
@@ -30,7 +39,30 @@ COMMENT_MARKERS: "dict[str, str] | None" = None
 
 
 def main() -> int:
-    """Main entry point - sets up import path and runs review."""
+    """Run the agentic PR review CLI workflow.
+
+    Purpose:
+        Load config, resolve event/ref inputs, run ReviewCoordinator, write
+        JSON/Markdown artifacts, optionally publish a GitHub PR comment, print
+        Markdown, and return a verdict-based exit code.
+    Important parameters:
+        Uses argparse results plus GITHUB_EVENT_PATH, REVIEW_BASE_REF,
+        REVIEW_HEAD_REF, REVIEW_PULL_NUMBER, GITHUB_REPOSITORY, and
+        GITHUB_TOKEN.
+    Return value:
+        0 when run.result.verdict == "LGTM"; otherwise 1.
+    Side effects:
+        Reads event JSON when present, writes artifact files, creates output
+        directories, may call GitHubClient.upsert_issue_comment(), and prints
+        Markdown to stdout.
+    Failure or fallback behavior:
+        Missing event path is ignored; invalid REVIEW_PULL_NUMBER becomes None;
+        GitHub comment publication is skipped unless same_repo, PR number,
+        repository, and token are all present.
+    Trace:
+        _parse_args(), _resolve_repo_root(), load_review_config(),
+        ReviewCoordinator.run(), _resolve_output_path(), GitHubClient.
+    """
     # Lazy-load dependencies to avoid import-time side effects
     _lazy_imports()
 
@@ -157,6 +189,24 @@ def _setup_import_path(repo_root: Path) -> None:
 
 
 def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the review script.
+
+    Purpose:
+        Define optional ref/PR overrides and output artifact paths.
+    Important parameters:
+        Reads process argv through argparse.
+    Return value:
+        argparse.Namespace with base_ref, head_ref, pr_number, json_out, and
+        markdown_out.
+    Side effects:
+        May print argparse help and exit when invoked with standard argparse
+        help/error behavior.
+    Failure or fallback behavior:
+        json_out and markdown_out default to artifacts/agentic-review paths.
+    Trace:
+        argparse.ArgumentParser, --base-ref, --head-ref, --pr-number,
+        --json-out, --markdown-out.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-ref", help="Override the review base ref.")
     parser.add_argument("--head-ref", help="Override the review head ref.")
@@ -175,6 +225,21 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _env_int(name: str) -> int | None:
+    """Parse an integer environment variable.
+
+    Purpose:
+        Convert optional numeric environment inputs such as REVIEW_PULL_NUMBER.
+    Important parameters:
+        name is the environment variable key.
+    Return value:
+        int when the variable exists and parses; otherwise None.
+    Side effects:
+        Reads os.environ.
+    Failure or fallback behavior:
+        Missing, empty, or non-integer values return None.
+    Trace:
+        os.environ.get(), int(raw.strip()).
+    """
     raw = os.environ.get(name)
     if not raw:
         return None
@@ -226,6 +291,22 @@ def _load_event_payload_if_available(
 
 
 def _resolve_repo_root() -> Path:
+    """Resolve the repository root used by this script.
+
+    Purpose:
+        Prefer GITHUB_WORKSPACE when present, otherwise use the script's
+        repository-relative parent path.
+    Important parameters:
+        None; reads GITHUB_WORKSPACE from the environment.
+    Return value:
+        Resolved Path for the workspace/repository root.
+    Side effects:
+        Reads os.environ.
+    Failure or fallback behavior:
+        If GITHUB_WORKSPACE is absent, falls back to Path(__file__).parents[2].
+    Trace:
+        os.environ.get("GITHUB_WORKSPACE"), Path.resolve(), REPO_ROOT.
+    """
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
         return Path(workspace).resolve()
@@ -234,6 +315,22 @@ def _resolve_repo_root() -> Path:
 
 
 def _resolve_output_path(repo_root: Path, raw_path: str) -> Path:
+    """Resolve an artifact output path.
+
+    Purpose:
+        Interpret CLI output paths relative to the repo root unless absolute.
+    Important parameters:
+        repo_root is the base directory; raw_path is the CLI-provided path.
+    Return value:
+        Absolute Path for artifact writing.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Absolute raw paths are returned unchanged; relative paths resolve under
+        repo_root.
+    Trace:
+        Path(raw_path), Path.is_absolute(), Path.resolve().
+    """
     path = Path(raw_path)
     if path.is_absolute():
         return path

--- a/scripts/github/repair_loop.py
+++ b/scripts/github/repair_loop.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Execute one bounded autonomous repair attempt on an agent branch."""
+"""Execute one bounded autonomous repair attempt for a pull request.
+
+This script is the command-line entry point for the autonomous repair workflow
+after a CI failure has been classified. It reads workflow event inputs, checks
+pull request labels and changed files through the GitHub helper client, applies
+the bounded repair policy from :mod:`blokus.automation`, and records retry state
+in a managed PR comment. Depending on the failure category and eligibility, it
+may run deterministic lint repair commands, commit and push changes to the PR
+branch, rerun failed CI jobs, or stop with labels that ask for human review.
+"""
 
 from __future__ import annotations
 
@@ -18,10 +27,53 @@ from gh_helpers import GitHubClient, load_event_payload
 
 
 def _run(command: list[str]) -> None:
+    """Run one local subprocess command and fail on a nonzero exit.
+
+    Purpose:
+        Centralize shell-out behavior for the deterministic repair commands used
+        by this workflow.
+    Important parameters:
+        command is an argv-style command list passed directly to
+        :func:`subprocess.run`.
+    Return value:
+        None.
+    Side effects:
+        Executes a subprocess in the current working directory.
+    Failure or fallback behavior:
+        :class:`subprocess.CalledProcessError` propagates because ``check=True``
+        is used. There is no retry or command-specific fallback in this helper.
+    Trace:
+        Wraps ``subprocess.run(command, check=True)`` and is called by
+        :func:`_commit_and_push` and the lint branch in :func:`main`.
+
+    Warning:
+        The command is executed locally as provided by the caller; maintainers
+        should review every call site before adding commands that mutate files,
+        install dependencies, or contact external services.
+    """
     subprocess.run(command, check=True)
 
 
 def _has_diff() -> bool:
+    """Return whether the working tree contains changes after repair commands.
+
+    Purpose:
+        Decide whether the lint repair path should commit and push a patch or
+        rerun failed CI jobs because no deterministic edit was produced.
+    Important parameters:
+        None.
+    Return value:
+        ``True`` when ``git status --short`` writes non-empty output; otherwise
+        ``False``.
+    Side effects:
+        Runs ``git status --short`` with captured text output.
+    Failure or fallback behavior:
+        :class:`subprocess.CalledProcessError` propagates because ``check=True``
+        is used. The caller does not attempt an alternate diff check.
+    Trace:
+        Uses :func:`subprocess.run` with ``["git", "status", "--short"]`` and
+        feeds the result into the lint branch in :func:`main`.
+    """
     result = subprocess.run(
         ["git", "status", "--short"],
         check=True,
@@ -32,6 +84,33 @@ def _has_diff() -> bool:
 
 
 def _commit_and_push(branch_name: str, pull_number: int) -> str:
+    """Commit all working-tree changes and push them to the PR branch.
+
+    Purpose:
+        Publish deterministic repair edits produced by the lint repair path.
+    Important parameters:
+        branch_name is used as the remote ref target in ``HEAD:{branch_name}``.
+        pull_number is interpolated into the repair commit message.
+    Return value:
+        The action summary string ``"pushed bounded repair patch"`` for the PR
+        comment body assembled by :func:`main`.
+    Side effects:
+        Configures the git author as ``github-actions[bot]``, stages every
+        working-tree change with ``git add -A``, creates a commit, and pushes to
+        ``origin``.
+    Failure or fallback behavior:
+        Any failing git command propagates :class:`subprocess.CalledProcessError`
+        through :func:`_run`. The function does not inspect branch protection,
+        remote permissions, or the contents of the staged patch.
+    Trace:
+        Calls :func:`_run` for ``git config``, ``git add -A``, ``git commit``,
+        and ``git push origin HEAD:{branch_name}``.
+
+    Warning:
+        ``git add -A`` stages all working-tree changes visible to the script, so
+        future repair commands must keep their write scope explicit before this
+        function is called.
+    """
     _run(["git", "config", "user.name", "github-actions[bot]"])
     _run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"])
     _run(["git", "add", "-A"])
@@ -41,6 +120,57 @@ def _commit_and_push(branch_name: str, pull_number: int) -> str:
 
 
 def main() -> int:
+    """Execute one bounded autonomous repair attempt.
+
+    Purpose:
+        Read workflow inputs, inspect pull request state, enforce
+        :func:`blokus.automation.repair_allowed`, apply one repair or rerun
+        action, update labels and comments, and persist retry state in the
+        repair comment.
+    Important parameters:
+        Reads ``GITHUB_EVENT_PATH``, ``GITHUB_REPOSITORY``, and ``GITHUB_TOKEN``
+        from :data:`os.environ`. The event payload is expected to contain
+        ``inputs`` with ``pull_number``, ``head_branch``, ``ci_run_id``, and
+        ``failure_category``.
+    Return value:
+        Returns ``0`` for handled code paths, including already-handled runs,
+        disallowed repairs, reruns, and attempted lint repairs.
+    Side effects:
+        Calls GitHub APIs through :class:`gh_helpers.GitHubClient`; may mutate
+        PR labels and comments, rerun failed jobs, run dependency installation,
+        run Ruff autofix, and commit or push git changes.
+    Failure or fallback behavior:
+        A previously handled ``ci_run_id`` exits without action. Disallowed
+        repairs remove ``repair-loop``, add ``agent-blocked`` and
+        ``needs-review``, write a stopped comment, and return ``0``. Allowed
+        non-lint categories rerun failed jobs within the retry budget, while
+        lint repairs rerun failed jobs only when Ruff produces no local diff.
+    Trace:
+        Uses :func:`load_event_payload`, :func:`repair_allowed`,
+        :func:`parse_state_marker`, :func:`render_state_marker`,
+        :data:`COMMENT_MARKERS`, :data:`REPAIR_STATE_MARKER`,
+        :class:`GitHubClient`, :func:`_run`, :func:`_has_diff`, and
+        :func:`_commit_and_push`.
+
+    Warning:
+        Environment variables and event payload keys are accessed directly. A
+        missing key raises before the script can write a repair comment.
+
+    Warning:
+        The lint path runs ``./scripts/install.sh``, installs ``ruff`` with pip,
+        and executes ``ruff check --fix .`` across the repository; this code does
+        not prove that resulting edits are limited to changed PR files.
+
+    Warning:
+        Retry state is recovered from managed issue comments using
+        :func:`parse_state_marker` and then coerced with ``int``. A malformed or
+        unexpected state payload can fail before label/comment fallback handling.
+
+    Warning:
+        GitHub token use is concentrated in :class:`GitHubClient`, which is
+        constructed from ``GITHUB_REPOSITORY`` and ``GITHUB_TOKEN`` and then used
+        for PR reads, label mutation, comment upserts, and failed-job reruns.
+    """
     payload = load_event_payload(os.environ["GITHUB_EVENT_PATH"])
     inputs = payload["inputs"]
     pull_number = int(inputs["pull_number"])

--- a/src/blokus/review/coordinator.py
+++ b/src/blokus/review/coordinator.py
@@ -1,4 +1,13 @@
-"""Coordinator for agentic PR review."""
+"""Coordinate one end-to-end agentic PR review run.
+
+This module builds diff context, runs deterministic static analysis,
+conditionally invokes LLM specialists, merges findings and uncertain risks, and
+renders the final Markdown review artifact. It owns the review-level flow for
+provider availability, forked pull requests, truncation risks, finding
+deduplication/capping, summary posture, and final verdict selection. The result
+is a bounded review artifact assembled from local context and optional provider
+responses, not an exhaustive or security-authoritative assessment.
+"""
 
 from __future__ import annotations
 
@@ -38,7 +47,26 @@ _SPECIALIST_BLOCKING_DEGRADING_RISKS = {
 
 @dataclass(frozen=True)
 class ReviewRun:
-    """Final bundled review outputs."""
+    """Final bundle returned by one coordinator run.
+
+    Purpose:
+        Keep the diff context, structured review result, rendered Markdown, and
+        static-analysis report together for callers.
+    Important parameters:
+        context is the ReviewContext used for review; result is the normalized
+        ReviewResult; markdown is rendered by render_review_markdown();
+        static_report is the StaticAnalysisReport produced or synthesized.
+    Return value:
+        Dataclass value returned by ReviewCoordinator.run().
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        May contain fallback context and a not_run static report when diff
+        context construction fails.
+    Trace:
+        ReviewCoordinator.run(), ReviewContext, ReviewResult,
+        StaticAnalysisReport.
+    """
 
     context: ReviewContext
     result: ReviewResult
@@ -68,7 +96,26 @@ class _RenderedBlockCache:
 
 
 class ReviewCoordinator:
-    """Run the end-to-end agentic PR review flow."""
+    """Coordinate diff, static, specialist, verdict, and rendering stages.
+
+    Purpose:
+        Orchestrate the agentic PR review pipeline from ReviewConfig to
+        ReviewRun.
+    Important parameters:
+        config is validated at construction and passed to StaticAnalyzer,
+        OpenRouterClient, SpecialistRunner, and renderer-related helpers.
+    Return value:
+        run() returns ReviewRun.
+    Side effects:
+        May call git-backed diff loading, static-analysis subprocesses,
+        provider-backed specialist requests, and Markdown rendering.
+    Failure or fallback behavior:
+        Diff-context failures create fallback context; unavailable providers and
+        forked PRs become uncertain risks.
+    Trace:
+        build_review_context(), StaticAnalyzer, OpenRouterClient.from_env(),
+        SpecialistRunner, render_review_markdown().
+    """
 
     def __init__(self, config: ReviewConfig) -> None:
         self.config = config
@@ -83,6 +130,31 @@ class ReviewCoordinator:
         head_ref: str | None = None,
         pr_number: int | None = None,
     ) -> ReviewRun:
+        """Run one complete agentic PR review.
+
+        Purpose:
+            Build review context, run static analysis, conditionally run
+            specialists, merge risks, dedupe/cap findings, compute summary and
+            verdict, and render Markdown.
+        Important parameters:
+            event_payload, base_ref, head_ref, and pr_number are forwarded to
+            build_review_context() or fallback context construction.
+        Return value:
+            ReviewRun containing context, ReviewResult, Markdown, and static
+            report.
+        Side effects:
+            Calls build_review_context(), StaticAnalyzer.analyze(),
+            OpenRouterClient.from_env(), SpecialistRunner, and
+            render_review_markdown().
+        Failure or fallback behavior:
+            Catches subprocess.CalledProcessError, KeyError, TypeError, and
+            ValueError from context construction; records provider and fork
+            skips as UncertainRisk values.
+        Trace:
+            _fallback_review_context(), _run_specialists(),
+            _append_diff_truncation_risk(), _dedupe_and_limit(),
+            _build_summary(), _build_verdict().
+        """
         try:
             context = build_review_context(
                 self.config,
@@ -196,6 +268,30 @@ class ReviewCoordinator:
         uncertain_risks: list[UncertainRisk],
         performance_requested: bool,
     ) -> tuple[list[Finding], list[UncertainRisk], bool]:
+        """Run applicable specialist reviewers and merge their responses.
+
+        Purpose:
+            Build rendered diff bundles, choose correctness/tests/performance
+            specialist specs, run provider calls concurrently, and merge
+            results.
+        Important parameters:
+            specialist_runner executes specialists; context supplies changed
+            files; findings and uncertain_risks are mutable accumulators;
+            performance_requested controls the performance specialist.
+        Return value:
+            Updated findings, updated uncertain_risks, and whether rendered diff
+            context was truncated.
+        Side effects:
+            Submits work to ThreadPoolExecutor and mutates the supplied lists.
+        Failure or fallback behavior:
+            Per-specialist failures are converted with
+            _specialist_failure_response(); prompt context truncation appends an
+            uncertain risk once.
+        Trace:
+            ThreadPoolExecutor, _RenderedBlockCache, _render_diff_bundle(),
+            prompt_context_was_truncated(),
+            _append_prompt_context_truncation_risk().
+        """
         reviewable_changed_files = tuple(changed_file for changed_file in context.changed_files if changed_file.patch.strip())
         reviewable_executable_files = tuple(
             changed_file for changed_file in context.executable_files if changed_file.patch.strip()
@@ -254,12 +350,48 @@ class ReviewCoordinator:
         files: tuple[ChangedFile, ...],
         rendered_diff: str,
     ) -> "SpecialistResponse":
+        """Run one specialist and convert exceptions into uncertainty.
+
+        Purpose:
+            Wrap SpecialistRunner.run() for one specialist request.
+        Important parameters:
+            specialist names the prompt/model route; files and rendered_diff
+            define the scoped review input.
+        Return value:
+            SpecialistResponse from the runner or _specialist_failure_response().
+        Side effects:
+            May call the configured provider through SpecialistRunner.
+        Failure or fallback behavior:
+            Any exception is caught and represented as an uncertain risk
+            response.
+        Trace:
+            SpecialistRunner.run(), _specialist_failure_response().
+        """
         try:
             return specialist_runner.run(specialist, context, files, rendered_diff)
         except Exception as exc:
             return _specialist_failure_response(specialist, exc)
 
     def _dedupe_and_limit(self, findings: list[Finding]) -> list[Finding]:
+        """Validate, deduplicate, rank, and cap review findings.
+
+        Purpose:
+            Keep only schema-valid findings, retain the highest-ranked
+            duplicate, sort by rank, and enforce config.max_findings.
+        Important parameters:
+            findings is the accumulated list from static and specialist
+            reviewers.
+        Return value:
+            Ordered list of at most config.max_findings Finding objects.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Invalid findings are dropped; lower-ranked duplicates are replaced
+            by stronger findings with the same dedupe key.
+        Trace:
+            _is_valid_finding(), Finding.dedupe_key(), Finding.rank(),
+            ALLOWED_FINDING_CATEGORIES.
+        """
         deduped: dict[tuple[str, str, int, str], Finding] = {}
         for finding in findings:
             if not _is_valid_finding(finding):
@@ -321,6 +453,27 @@ class ReviewCoordinator:
         provider_available: bool,
         performance_review_covered: bool,
     ) -> ReviewSummary:
+        """Build the top-level review posture summary.
+
+        Purpose:
+            Combine context impact, findings, static posture, performance
+            request, and provider availability into ReviewSummary.
+        Important parameters:
+            context supplies impact and changed files; findings drive risk,
+            test, and performance posture; static_report supplies
+            static_analysis_posture.
+        Return value:
+            ReviewSummary.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Test posture falls back to review_recommended for source/schema/
+            fixture changes without test findings; performance posture reflects
+            whether a requested provider-backed review was available.
+        Trace:
+            ReviewSummary, StaticAnalysisReport.posture, Finding.category,
+            Finding.blocking_recommendation.
+        """
         overall_risk = context.impact
         if findings:
             overall_risk = max(
@@ -354,6 +507,25 @@ class ReviewCoordinator:
         )
 
     def _build_verdict(self, findings: list[Finding], uncertain_risks: list[UncertainRisk]) -> str:
+        """Compute the final review verdict from findings and uncertainty.
+
+        Purpose:
+            Return NEEDS CHANGES for blocking findings, DISCUSS for blocking
+            uncertainty, otherwise LGTM.
+        Important parameters:
+            findings are already deduped/capped; uncertain_risks are accumulated
+            from diff, static, provider, and specialist stages.
+        Return value:
+            "NEEDS CHANGES", "DISCUSS", or "LGTM".
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            _requires_discussion() exempts configured non-blocking uncertain
+            risks and some OpenRouter specialist failures.
+        Trace:
+            _requires_discussion(), _NON_BLOCKING_UNCERTAIN_RISKS,
+            Finding.blocking_recommendation.
+        """
         if any(finding.blocking_recommendation for finding in findings):
             return "NEEDS CHANGES"
         if any(_requires_discussion(risk) for risk in uncertain_risks):
@@ -499,6 +671,23 @@ def _finalize_rendered_bundle(parts: list[str], total_length: int, truncated: bo
 
 
 def _specialist_failure_response(specialist: str, error: Exception) -> "SpecialistResponse":
+    """Convert a specialist exception into a SpecialistResponse.
+
+    Purpose:
+        Keep one failed specialist from aborting the whole coordinator run.
+    Important parameters:
+        specialist names the failed specialist; error is serialized into
+        reason_uncertain.
+    Return value:
+        SpecialistResponse with no findings, one UncertainRisk, and empty note.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        The original exception is not re-raised by this helper.
+    Trace:
+        _run_specialist(), _run_specialists(), SpecialistResponse,
+        UncertainRisk.
+    """
     return SpecialistResponse(
         findings=(),
         uncertain_risks=(
@@ -541,6 +730,24 @@ def _truncate_text(text: str, limit: int, marker: str) -> str:
 
 
 def _append_diff_truncation_risk(uncertain_risks: list[UncertainRisk]) -> None:
+    """Append a de-duplicated risk for truncated diff context.
+
+    Purpose:
+        Record that stored patches or rendered specialist bundles exceeded size
+        limits and may omit hunks.
+    Important parameters:
+        uncertain_risks is the mutable accumulator list.
+    Return value:
+        None.
+    Side effects:
+        May append one UncertainRisk.
+    Failure or fallback behavior:
+        Does not append if a risk with the same risk text already exists.
+    Trace:
+        MAX_RENDERED_DIFF_CHARS, MAX_RENDERED_PATCH_CHARS,
+        _RENDERED_BUNDLE_TRUNCATION_MARKER,
+        _RENDERED_PATCH_TRUNCATION_MARKER.
+    """
     risk = UncertainRisk(
         risk="Diff context was truncated for scale.",
         reason_uncertain="One or more stored patches or rendered specialist diff bundles exceeded the internal size limits, so omitted hunks may not have been reviewed in full.",
@@ -569,6 +776,22 @@ def _append_diff_analysis_truncation_risk(uncertain_risks: list[UncertainRisk]) 
 
 
 def _append_prompt_context_truncation_risk(uncertain_risks: list[UncertainRisk]) -> None:
+    """Append a de-duplicated risk for truncated prompt metadata context.
+
+    Purpose:
+        Record that specialist prompts capped commit subjects or changed-path
+        lists.
+    Important parameters:
+        uncertain_risks is the mutable accumulator list.
+    Return value:
+        None.
+    Side effects:
+        May append one UncertainRisk.
+    Failure or fallback behavior:
+        Does not append if a risk with the same risk text already exists.
+    Trace:
+        prompt_context_was_truncated(), SpecialistRunner prompt context limits.
+    """
     risk = UncertainRisk(
         risk="Commit or file-list context was truncated for scale.",
         reason_uncertain="The specialist prompts capped commit subjects or changed-path lists to stay within a bounded context window, so some metadata context was omitted.",
@@ -636,6 +859,24 @@ def _fallback_review_context(
     head_ref: str | None,
     pr_number: int | None,
 ) -> ReviewContext:
+    """Build minimal context when diff-backed context construction fails.
+
+    Purpose:
+        Preserve enough PR/ref metadata to render a review artifact after local
+        refs or diff loading fail.
+    Important parameters:
+        event_payload, base_ref, head_ref, and pr_number are used to recover
+        payload, refs, and same_repo when possible.
+    Return value:
+        ReviewContext with no commits, changed files, executable files, or raw
+        diff; impact is "moderate" and branch_name is "unavailable".
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Falls back to origin/main and HEAD when payload/ref values are absent.
+    Trace:
+        _fallback_payload(), _fallback_same_repo(), ReviewContext.
+    """
     payload = _fallback_payload(event_payload, base_ref, head_ref, pr_number)
     return ReviewContext(
         pr=payload,

--- a/src/blokus/review/diff.py
+++ b/src/blokus/review/diff.py
@@ -1,4 +1,13 @@
-"""Git diff loading and review-context construction."""
+"""Build diff-backed review context for the agentic PR review flow.
+
+This module resolves review refs, reads local git history, streams unified diff
+patches, and converts patch metadata into ReviewContext and ChangedFile objects.
+It tracks changed-line spans, path/category metadata, executable files,
+performance-sensitive markers, excluded files, commit-context limits, and
+stored patch truncation for downstream static and LLM review. The parser is
+bounded and local-git based; it does not claim parity with GitHub's PR file
+model or complete repository history.
+"""
 
 from __future__ import annotations
 
@@ -32,6 +41,25 @@ _PATCH_TRUNCATION_MARKER = "\n... [diff context truncated for scale]\n"
 
 @dataclass(frozen=True)
 class _PatchBlock:
+    """Internal normalized patch block produced from one git diff file block.
+
+    Purpose:
+        Carry parsed patch metadata before conversion to ChangedFile.
+    Important parameters:
+        path is the selected review path, status is git-like status metadata,
+        patch is bounded stored diff text, line_spans are changed post-change
+        lines, old_path carries rename/copy source metadata, and the boolean
+        fields carry performance/truncation signals.
+    Return value:
+        Dataclass value consumed by _load_changed_files().
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Instances are only built when _PatchAccumulator.build() can determine a
+        non-null path.
+    Trace:
+        _PatchAccumulator.build(), _load_changed_files(), ChangedFile.
+    """
     path: str
     status: str
     patch: str
@@ -44,12 +72,49 @@ class _PatchBlock:
 
 @dataclass
 class _LineSpanTracker:
+    """Track post-change line spans while reading unified diff lines.
+
+    Purpose:
+        Convert hunk headers and patch body lines into LineSpan values for
+        additions and deletion-only anchors.
+    Important parameters:
+        spans stores completed spans, current_line tracks the new-file hunk
+        line, span_start tracks an active addition span, and deletion_anchor
+        tracks zero-line hunks.
+    Return value:
+        finish() returns tuple[LineSpan, ...].
+    Side effects:
+        Mutates tracker state while feed() is called.
+    Failure or fallback behavior:
+        Lines outside hunks and file header lines are ignored; deletion-only
+        hunks produce a one-line anchor.
+    Trace:
+        _HUNK_RE, feed(), finish(), _flush_current_hunk(), LineSpan.
+    """
     spans: list[LineSpan] = field(default_factory=list)
     current_line: int | None = None
     span_start: int | None = None
     deletion_anchor: int | None = None
 
     def feed(self, raw_line: str) -> None:
+        """Consume one raw unified diff line and update changed-line state.
+
+        Purpose:
+            Start new hunks, track added-line spans, ignore deletion/context
+            marker lines as appropriate, and flush completed spans.
+        Important parameters:
+            raw_line is one line from a git patch, without requiring a trailing
+            newline.
+        Return value:
+            None.
+        Side effects:
+            Mutates current_line, span_start, deletion_anchor, and spans.
+        Failure or fallback behavior:
+            Non-hunk lines before any current hunk, `---`/`+++` file headers,
+            deletion lines, and `\\ No newline` markers do not create additions.
+        Trace:
+            _HUNK_RE, _flush_current_hunk(), LineSpan.
+        """
         if raw_line.startswith("diff --git "):
             if self.current_line is not None:
                 self._flush_current_hunk()
@@ -91,6 +156,23 @@ class _LineSpanTracker:
         self.current_line += 1
 
     def finish(self) -> tuple[LineSpan, ...]:
+        """Flush any active hunk state and return parsed changed-line spans.
+
+        Purpose:
+            Complete the final active addition span or deletion anchor after all
+            patch lines have been fed.
+        Important parameters:
+            Uses the tracker's current mutable state.
+        Return value:
+            tuple of LineSpan objects.
+        Side effects:
+            May append one final span and clears active span/deletion state
+            through _flush_current_hunk().
+        Failure or fallback behavior:
+            If no hunk was active, returns the spans already collected.
+        Trace:
+            _flush_current_hunk(), LineSpan.
+        """
         if self.current_line is not None:
             self._flush_current_hunk()
         return tuple(self.spans)
@@ -107,6 +189,26 @@ class _LineSpanTracker:
 
 @dataclass
 class _PatchAccumulator:
+    """Accumulate one git diff file block into a bounded _PatchBlock.
+
+    Purpose:
+        Track paths, status, line spans, performance sensitivity, and stored
+        patch text while _iter_git_patch_blocks() streams stdout.
+    Important parameters:
+        config supplies performance markers. tracker parses line spans.
+        old_path/new_path/status mirror patch metadata. stored_parts and
+        stored_chars implement MAX_STORED_PATCH_CHARS truncation.
+    Return value:
+        build() returns _PatchBlock or None.
+    Side effects:
+        Mutates accumulator state as each patch line is added.
+    Failure or fallback behavior:
+        build() returns None when no path can be inferred; truncated patches are
+        marked with _PATCH_TRUNCATION_MARKER.
+    Trace:
+        add_line(), build(), _track_paths(), _track_performance(),
+        _append_bounded(), MAX_STORED_PATCH_CHARS.
+    """
     config: ReviewConfig
     tracker: _LineSpanTracker = field(default_factory=_LineSpanTracker)
     status: str = "M"
@@ -131,6 +233,26 @@ class _PatchAccumulator:
         self._diff_marker_pattern = _diff_marker_pattern(self.config.performance.diff_markers)
 
     def add_line(self, line: str) -> None:
+        """Process one patch line into all accumulator subsystems.
+
+        Purpose:
+            Feed the line-span tracker, update path/status metadata, update
+            performance sensitivity, and append bounded patch context.
+        Important parameters:
+            line is one stdout line from `git diff`, with the trailing newline
+            already stripped.
+        Return value:
+            None.
+        Side effects:
+            Mutates tracker, path/status fields, performance_sensitive,
+            stored_parts, stored_chars, and patch_truncated.
+        Failure or fallback behavior:
+            Once patch_truncated is true, further patch text is not stored,
+            though line-span and metadata tracking still continue.
+        Trace:
+            _LineSpanTracker.feed(), _track_paths(), _track_performance(),
+            _append_bounded().
+        """
         if self._should_skip_remaining_lines():
             if self._should_scan_post_cap_performance(line):
                 self._track_performance(line)
@@ -148,6 +270,25 @@ class _PatchAccumulator:
         self._append_bounded(line)
 
     def build(self) -> _PatchBlock | None:
+        """Finalize accumulated patch metadata into a _PatchBlock.
+
+        Purpose:
+            Choose the review path, append the truncation marker if needed,
+            flush line spans, and expose rename/copy source metadata.
+        Important parameters:
+            Uses accumulated old_path, new_path, stored_parts, tracker, status,
+            performance_sensitive, and patch_truncated.
+        Return value:
+            _PatchBlock when a path is available; otherwise None.
+        Side effects:
+            Calls tracker.finish(), which may mutate tracker state by flushing a
+            final span.
+        Failure or fallback behavior:
+            Uses old_path when new_path is missing or `/dev/null`; returns None
+            if neither path is available.
+        Trace:
+            _PATCH_TRUNCATION_MARKER, _LineSpanTracker.finish(), _PatchBlock.
+        """
         path = self.new_path if self.new_path and self.new_path != "/dev/null" else self.old_path
         if path is None:
             return None
@@ -280,7 +421,31 @@ def build_review_context(
     head_ref: str | None = None,
     pr_number: int | None = None,
 ) -> ReviewContext:
-    """Collect diff-backed review context for one review run."""
+    """Collect the diff-backed inputs for one review run.
+
+    Purpose:
+        Resolve base/head refs, read commit metadata, load changed files, filter
+        excluded paths, identify executable files, and assemble ReviewContext.
+    Important parameters:
+        config supplies repo_root and excluded_globs. event_payload may provide
+        pull_request base/head SHAs and PR number. base_ref, head_ref, and
+        pr_number are fallback explicit inputs.
+    Return value:
+        ReviewContext with ReviewPayload, resolved refs, branch name, bounded
+        commit subjects, included changed files, executable files, impact, bias
+        risks, same_repo, commit_context_truncated, and raw_diff="".
+    Side effects:
+        Runs git subprocesses through _git_output(), _git_lines(), and
+        _load_changed_files().
+    Failure or fallback behavior:
+        Missing or invalid git refs can raise subprocess.CalledProcessError via
+        _git_output() or _iter_git_patch_blocks(). Partial PR payloads fall back
+        through _resolve_refs().
+    Trace:
+        _resolve_refs(), _git_output(), _git_lines(), MAX_REVIEW_CONTEXT_COMMITS,
+        _load_changed_files(), _is_excluded(), _classify_impact(),
+        _infer_bias_risks().
+    """
 
     base_value, head_value, number, same_repo = _resolve_refs(event_payload, base_ref, head_ref, pr_number)
     base_sha = _git_output(config.repo_root, ["rev-parse", base_value]).strip()
@@ -314,7 +479,26 @@ def build_review_context(
 
 
 def should_run_performance_review(config: ReviewConfig, context: ReviewContext) -> bool:
-    """Return whether the performance specialist should run."""
+    """Return whether the performance specialist should run for this context.
+
+    Purpose:
+        Check whether any executable changed file was already marked
+        performance_sensitive during patch accumulation.
+    Important parameters:
+        context supplies executable_files. config is accepted for the public
+        call shape but is currently unused.
+    Return value:
+        True if any executable ChangedFile has performance_sensitive=True;
+        otherwise False.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Non-executable files do not trigger this check even if marked
+        performance_sensitive.
+    Trace:
+        ChangedFile.performance_sensitive, ReviewContext.executable_files,
+        _PatchAccumulator._track_performance().
+    """
 
     del config
     return any(changed_file.performance_sensitive for changed_file in context.executable_files)
@@ -326,6 +510,24 @@ def _resolve_refs(
     head_ref: str | None,
     pr_number: int | None,
 ) -> tuple[str, str, int | None, bool]:
+    """Resolve review base/head refs and PR metadata.
+
+    Purpose:
+        Prefer pull_request base/head SHAs from an event payload when both are
+        present, otherwise fall back to explicit refs or default local refs.
+    Important parameters:
+        event_payload may contain a pull_request dict. base_ref, head_ref, and
+        pr_number are fallback values.
+    Return value:
+        (base_ref_or_sha, head_ref_or_sha, pr_number_or_none, same_repo).
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Partial or malformed pull_request payloads fall back to base_ref or
+        "origin/main", head_ref or "HEAD", pr_number, and same_repo=True.
+    Trace:
+        _nested_sha(), _optional_int(), _same_repo().
+    """
     resolved_base = base_ref or "origin/main"
     resolved_head = head_ref or "HEAD"
 
@@ -347,6 +549,26 @@ def _resolve_refs(
 
 
 def _load_changed_files(config: ReviewConfig, base_ref: str, head_ref: str) -> tuple[ChangedFile, ...]:
+    """Load changed files from a three-dot git diff and normalize them.
+
+    Purpose:
+        Stream patch blocks for `base_ref...head_ref` and convert each block to
+        a ChangedFile with executable, category, rename, performance, and
+        truncation metadata.
+    Important parameters:
+        config supplies repo_root and parsing/performance settings. base_ref and
+        head_ref are expected to be git-resolvable refs or SHAs.
+    Return value:
+        tuple[ChangedFile, ...].
+    Side effects:
+        Runs git diff indirectly through _iter_git_patch_blocks().
+    Failure or fallback behavior:
+        Propagates subprocess.CalledProcessError from _iter_git_patch_blocks()
+        when git exits non-zero.
+    Trace:
+        _iter_git_patch_blocks(), _is_executable_path(), _categorize_path(),
+        ChangedFile.
+    """
     diff_ref = f"{base_ref}...{head_ref}"
     changed_files: list[ChangedFile] = []
     stored_patch_files = 0
@@ -393,6 +615,21 @@ def _current_branch(repo_root: Path) -> str:
 
 
 def _parse_line_spans(patch_text: str) -> list[LineSpan]:
+    """Parse changed post-change line spans from patch text.
+
+    Purpose:
+        Convenience wrapper that feeds split patch lines into _LineSpanTracker.
+    Important parameters:
+        patch_text is unified diff text for one or more file blocks.
+    Return value:
+        list[LineSpan] produced by the tracker.
+    Side effects:
+        None outside local tracker state.
+    Failure or fallback behavior:
+        Lines not recognized by _LineSpanTracker.feed() are ignored.
+    Trace:
+        _LineSpanTracker.feed(), _LineSpanTracker.finish(), _HUNK_RE.
+    """
     tracker = _LineSpanTracker()
     for raw_line in patch_text.splitlines():
         tracker.feed(raw_line)
@@ -404,6 +641,26 @@ def _iter_git_patch_blocks(
     repo_root: Path,
     args: list[str],
 ) -> Iterator[_PatchBlock]:
+    """Stream git patch output into _PatchBlock objects.
+
+    Purpose:
+        Run a git command, split stdout into file-level diff blocks, and yield
+        normalized patch blocks without first storing the full diff output.
+    Important parameters:
+        config is passed to each _PatchAccumulator. repo_root is the subprocess
+        cwd. args are appended after `git`.
+    Return value:
+        Iterator[_PatchBlock].
+    Side effects:
+        Starts subprocess.Popen(["git", *args]), reads stdout, starts a daemon
+        thread to drain stderr, closes pipes, and waits for the process.
+    Failure or fallback behavior:
+        Raises subprocess.CalledProcessError with stderr if git exits non-zero.
+        Blocks with no inferred path are skipped through _PatchAccumulator.build().
+    Trace:
+        subprocess.Popen, threading.Thread, _PatchAccumulator.add_line(),
+        _PatchAccumulator.build().
+    """
     process = subprocess.Popen(
         ["git", *args],
         cwd=repo_root,
@@ -517,6 +774,22 @@ def _optional_int(value: object, default: int | None) -> int | None:
 
 
 def _classify_impact(changed_files: tuple[ChangedFile, ...]) -> str:
+    """Classify coarse review impact from included changed paths.
+
+    Purpose:
+        Assign low/moderate/high/critical impact using path heuristics.
+    Important parameters:
+        changed_files supplies already-filtered ChangedFile paths.
+    Return value:
+        "low", "moderate", "high", or "critical".
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Empty changes are "low"; only hard-coded critical markers, `.github/`,
+        and known path prefixes affect higher levels.
+    Trace:
+        critical_markers, path prefix checks in _classify_impact().
+    """
     if not changed_files:
         return "low"
 
@@ -541,6 +814,24 @@ def _classify_impact(changed_files: tuple[ChangedFile, ...]) -> str:
 
 
 def _infer_bias_risks(branch_name: str, commits: list[str]) -> tuple[str, ...]:
+    """Produce ordered bias-risk prompts from branch and commit text.
+
+    Purpose:
+        Return the review flow's standard bias-risk labels and prioritize
+        self-declared-correctness-bias when branch/commit text contains matching
+        terms.
+    Important parameters:
+        branch_name and commit subject strings form weak_context.
+    Return value:
+        tuple[str, ...] with duplicates removed while preserving order.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        If _SELF_DECLARED_RE does not match, self-declared-correctness-bias is
+        appended rather than prepended.
+    Trace:
+        _SELF_DECLARED_RE, MAX_REVIEW_CONTEXT_COMMITS, dict.fromkeys().
+    """
     risks = [
         "authority-bias",
         "reverse-authority-bias",
@@ -559,6 +850,22 @@ def _infer_bias_risks(branch_name: str, commits: list[str]) -> tuple[str, ...]:
 
 
 def _categorize_path(path: str) -> list[str]:
+    """Return simple path categories used by downstream review stages.
+
+    Purpose:
+        Classify a changed path as python, shell, workflow, schema, fixture,
+        test, and/or docs.
+    Important parameters:
+        path is a normalized repository-relative path.
+    Return value:
+        list[str] of zero or more categories.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Unknown paths return an empty list; categories are suffix/prefix based.
+    Trace:
+        _load_changed_files(), ChangedFile.categories.
+    """
     categories: list[str] = []
 
     if path.endswith(".py"):
@@ -584,10 +891,45 @@ def _is_executable_path(path: str) -> bool:
 
 
 def _is_excluded(config: ReviewConfig, path: str) -> bool:
+    """Return whether a path should be removed from review context.
+
+    Purpose:
+        Apply configured fnmatch-style excluded globs after changed files are
+        loaded.
+    Important parameters:
+        config.excluded_globs supplies patterns; path is repository-relative.
+    Return value:
+        True when any pattern matches, otherwise False.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Empty excluded_globs means no path is excluded.
+    Trace:
+        fnmatch.fnmatch(), build_review_context().
+    """
     return any(fnmatch.fnmatch(path, pattern) for pattern in config.excluded_globs)
 
 
 def _git_output(repo_root: Path, args: list[str]) -> str:
+    """Run a git command and return captured stdout.
+
+    Purpose:
+        Execute small git commands used for ref resolution, branch lookup, and
+        commit subjects.
+    Important parameters:
+        repo_root is subprocess cwd. args are appended after `git`.
+    Return value:
+        Completed stdout as text.
+    Side effects:
+        Runs subprocess.run(["git", *args], cwd=repo_root, check=True,
+        capture_output=True, text=True).
+    Failure or fallback behavior:
+        Non-zero git exit raises subprocess.CalledProcessError because
+        check=True.
+    Trace:
+        subprocess.run(), build_review_context(), _current_branch(),
+        _git_lines().
+    """
     completed = subprocess.run(
         ["git", *args],
         cwd=repo_root,

--- a/src/blokus/review/provider.py
+++ b/src/blokus/review/provider.py
@@ -1,4 +1,14 @@
-"""OpenRouter-backed model provider for agentic review."""
+"""OpenRouter-backed provider client for agentic review specialists.
+
+This module loads the OpenRouter API key from the environment, builds
+chat-completions requests, sends specialist prompt text to the configured
+provider URL, retries selected transient failures, and extracts returned message
+content. Provider, transport, decoding, and response-shape problems are
+normalized into ProviderUnavailable so callers can surface review uncertainty.
+This module wraps an external API boundary; it does not prove provider
+availability, response stability, credential safety outside this code, or schema
+guarantees for the returned content.
+"""
 
 from __future__ import annotations
 
@@ -22,12 +32,49 @@ _OPENROUTER_REQUEST_SEMAPHORE = threading.Semaphore(_MAX_CONCURRENT_OPENROUTER_R
 
 
 class ProviderUnavailable(RuntimeError):
-    """Raised when the LLM provider cannot be used."""
+    """Raised when the OpenRouter provider cannot complete review work.
+
+    Purpose:
+        Normalize credential, request, retry, decoding, and response-shape
+        failures into one exception type for coordinator/specialist handling.
+    Important parameters:
+        Inherits RuntimeError message text from each raising branch.
+    Return value:
+        Exception type; no return value.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Raised by OpenRouterClient.from_env() and OpenRouterClient.complete()
+        instead of returning partial provider content.
+    Trace:
+        OpenRouterClient.from_env(), OpenRouterClient.complete(),
+        coordinator ProviderUnavailable handling.
+    """
 
 
 @dataclass(frozen=True)
 class OpenRouterClient:
-    """Thin OpenRouter client using the chat-completions API."""
+    """Small OpenRouter chat-completions client for agentic review.
+
+    Purpose:
+        Hold provider configuration and send specialist prompts to the
+        OpenRouter chat-completions endpoint.
+    Important parameters:
+        api_key is used for the Authorization header; base_url is normalized by
+        from_env(); timeout_seconds is passed to urlopen(); max_retries controls
+        retry attempts.
+    Return value:
+        complete() returns stripped message content from the first response
+        choice.
+    Side effects:
+        Sends HTTP POST requests through urllib.request.urlopen().
+    Failure or fallback behavior:
+        Raises ProviderUnavailable for missing credentials, invalid retry
+        budget, exhausted retries, invalid JSON, missing body, or unexpected
+        response shape.
+    Trace:
+        from_env(), complete(), Request, urlopen, ProviderUnavailable.
+    """
 
     api_key: str
     base_url: str
@@ -36,6 +83,23 @@ class OpenRouterClient:
 
     @classmethod
     def from_env(cls, config: ReviewConfig) -> "OpenRouterClient":
+        """Create an OpenRouterClient from environment and review config.
+
+        Purpose:
+            Load OPENROUTER_API_KEY and combine it with provider settings from
+            ReviewConfig.
+        Important parameters:
+            config.provider supplies base_url, timeout_seconds, and max_retries.
+        Return value:
+            OpenRouterClient with base_url stripped of trailing slashes.
+        Side effects:
+            Reads os.environ["OPENROUTER_API_KEY"] through os.environ.get().
+        Failure or fallback behavior:
+            Raises ProviderUnavailable when the environment variable is absent
+            or falsey.
+        Trace:
+            os.environ.get(), ReviewConfig.provider, ProviderUnavailable.
+        """
         api_key = os.environ.get("OPENROUTER_API_KEY")
         if not api_key:
             raise ProviderUnavailable("`OPENROUTER_API_KEY` is not set.")
@@ -47,6 +111,30 @@ class OpenRouterClient:
         )
 
     def complete(self, *, model: str, system_prompt: str, user_prompt: str) -> str:
+        """Send one chat-completions request and return message content.
+
+        Purpose:
+            Submit specialist prompt text to OpenRouter and extract the first
+            choice's message content.
+        Important parameters:
+            model is serialized into the JSON payload; system_prompt and
+            user_prompt are sent as chat messages.
+        Return value:
+            Stripped string content from choices[0].message.content.
+        Side effects:
+            Builds a urllib Request, adds Content-Type, Authorization, and
+            Accept headers, sends HTTP requests with urlopen(), and may sleep
+            between retry attempts.
+        Failure or fallback behavior:
+            Negative max_retries raises immediately. Retryable HTTP errors,
+            URLError, TimeoutError, JSONDecodeError, and UnicodeDecodeError
+            retry until the attempt budget is exhausted. Non-retryable HTTP
+            errors, exhausted network retries, invalid final JSON, empty body,
+            and unexpected response shape raise ProviderUnavailable.
+        Trace:
+            Request(), request.add_header(), urlopen(timeout=timeout_seconds),
+            _is_retryable_http_error(), _sleep_before_retry(), json.loads().
+        """
         if self.max_retries < 0:
             raise ProviderUnavailable("OpenRouter `max_retries` must be greater than or equal to 0.")
         if self.max_retries > MAX_PROVIDER_RETRIES:
@@ -184,10 +272,41 @@ def _normalize_message_content(content: object) -> str:
 
 
 def _is_retryable_http_error(error: HTTPError) -> bool:
+    """Return whether an HTTPError status should be retried.
+
+    Purpose:
+        Centralize the retryable HTTP status allowlist.
+    Important parameters:
+        error is urllib.error.HTTPError.
+    Return value:
+        True for status codes 408, 425, 429, 500, 502, 503, or 504.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Any status code outside the set is treated as non-retryable by
+        complete().
+    Trace:
+        OpenRouterClient.complete() HTTPError branch.
+    """
     return error.code in {408, 425, 429, 500, 502, 503, 504}
 
 
 def _sleep_before_retry(attempt: int, error: HTTPError | None = None) -> None:
+    """Sleep before the next provider retry attempt.
+
+    Purpose:
+        Apply a small capped linear backoff between retryable provider failures.
+    Important parameters:
+        attempt is the 1-based attempt number passed by complete().
+    Return value:
+        None.
+    Side effects:
+        Calls time.sleep().
+    Failure or fallback behavior:
+        Sleep duration is min(0.25 * attempt, 1.0).
+    Trace:
+        time.sleep(), OpenRouterClient.complete() retry branches.
+    """
     time.sleep(_retry_delay_seconds(attempt, error))
 
 

--- a/src/blokus/review/specialists.py
+++ b/src/blokus/review/specialists.py
@@ -1,4 +1,15 @@
-"""Prompt-driven specialist review orchestration."""
+"""Build and validate prompt-driven specialist review responses.
+
+This module builds prompt payloads for specialist LLM reviewers and sends
+bounded diff context to the configured provider. It loads common and
+specialist-specific prompt assets, constructs user prompts with changed files,
+commits, bias risks, and rendered diff text, then parses provider JSON
+responses. Accepted findings are normalized only when they reference changed
+files and overlap touched line spans; malformed, incomplete, or unrelated
+output is discarded or converted into UncertainRisk where the parser explicitly
+does so. The module is a prompt and response-validation layer, not proof that
+LLM findings are complete, deterministic, or automatically correct.
+"""
 
 from __future__ import annotations
 
@@ -28,7 +39,26 @@ class _PromptContextBlocks:
 
 @dataclass(frozen=True)
 class SpecialistRunner:
-    """Invoke specialist prompts against the configured provider."""
+    """Invoke specialist prompt reviews through the configured provider.
+
+    Purpose:
+        Load common and specialist prompt assets, build a bounded user prompt,
+        call the provider, and parse the specialist's JSON response.
+    Important parameters:
+        config supplies prompt paths and model selection; provider is an
+        OpenRouterClient-compatible object used by provider.complete().
+    Return value:
+        run() returns SpecialistResponse.
+    Side effects:
+        May read prompt files through load_prompt() and submit prompt text plus
+        rendered diff context to provider.complete().
+    Failure or fallback behavior:
+        Missing prompt assets return a SpecialistResponse with an UncertainRisk;
+        empty file sets return a no-findings response without provider calls.
+    Trace:
+        _common_prompt, _specialist_prompt(), _build_user_prompt(),
+        OpenRouterClient.complete(), _parse_specialist_response().
+    """
 
     config: ReviewConfig
     provider: OpenRouterClient
@@ -50,6 +80,29 @@ class SpecialistRunner:
         files: tuple[ChangedFile, ...],
         rendered_diff: str,
     ) -> SpecialistResponse:
+        """Run one specialist review and normalize its response.
+
+        Purpose:
+            Combine shared and specialist prompts, build the user prompt, submit
+            it to the provider, and parse the provider response into review
+            data.
+        Important parameters:
+            specialist selects `review-{specialist}` prompt and model; context,
+            files, and rendered_diff define the scoped review input.
+        Return value:
+            SpecialistResponse containing accepted findings, uncertain risks,
+            and note text.
+        Side effects:
+            Reads prompt assets and calls provider.complete() with model,
+            system_prompt, and user_prompt.
+        Failure or fallback behavior:
+            No files returns a note-only response; FileNotFoundError while
+            loading prompts returns an UncertainRisk and skips
+            provider.complete().
+        Trace:
+            load_prompt(), config.model_for(), _build_user_prompt(),
+            provider.complete(), _parse_specialist_response().
+        """
         if not files:
             return SpecialistResponse(findings=(), note="No relevant files were available for this specialist.")
 
@@ -80,6 +133,24 @@ class SpecialistRunner:
         return _parse_specialist_response(raw_response, specialist, files)
 
     def _specialist_prompt(self, specialist: str) -> str:
+        """Load and cache a specialist-specific prompt asset.
+
+        Purpose:
+            Resolve `.github/prompts/review-{specialist}.md` through
+            load_prompt() once per SpecialistRunner instance.
+        Important parameters:
+            specialist is the prompt suffix used in `review-{specialist}`.
+        Return value:
+            Prompt text.
+        Side effects:
+            Reads from the configured prompt directory on cache miss and mutates
+            _specialist_prompt_cache.
+        Failure or fallback behavior:
+            Propagates FileNotFoundError to run(), which converts it into an
+            UncertainRisk response.
+        Trace:
+            load_prompt(), _specialist_prompt_cache, run().
+        """
         prompt = self._specialist_prompt_cache.get(specialist)
         if prompt is None:
             prompt = load_prompt(self.config, f"review-{specialist}")
@@ -93,6 +164,24 @@ def _build_user_prompt(
     files: tuple[ChangedFile, ...],
     rendered_diff: str,
 ) -> str:
+    """Build the user-facing prompt body for a specialist.
+
+    Purpose:
+        Combine file list, impact, branch, commit subjects, bias risks, response
+        JSON shape, finding limit instruction, and rendered diff text.
+    Important parameters:
+        specialist names the reviewer role; context supplies metadata and bias
+        risks; files scope prompt context; rendered_diff is the diff body.
+    Return value:
+        Stripped prompt string sent to provider.complete().
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Prompt context file/commit lists may contain omission notes produced by
+        _build_prompt_context_blocks().
+    Trace:
+        _build_prompt_context_blocks(), MAX_PROMPT_FILES, MAX_PROMPT_COMMITS.
+    """
     prompt_context = _build_prompt_context_blocks(context, files)
     bias_block = "\n".join(f"- {risk}" for risk in context.bias_risks)
 
@@ -151,6 +240,30 @@ def _parse_specialist_response(
     specialist: str,
     files: tuple[ChangedFile, ...],
 ) -> SpecialistResponse:
+    """Parse provider JSON into validated SpecialistResponse data.
+
+    Purpose:
+        Load JSON, accept only complete finding objects that match changed files
+        and touched line spans, preserve valid uncertain risks, and cap findings
+        to three.
+    Important parameters:
+        raw_response is provider text; specialist is used for source and
+        fallback stable IDs; files are the changed files this specialist was
+        asked to review.
+    Return value:
+        SpecialistResponse with tuple(findings[:3]), uncertain risks, and note.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Invalid JSON returns an empty response with an invalid-response note;
+        missing required finding keys, invalid line numbers, unmatched paths,
+        and non-overlapping line spans are discarded. Unmatched paths add one or
+        more UncertainRisk entries.
+    Trace:
+        _load_json_object(), _dict_list(), _index_changed_paths(),
+        _lookup_changed_file(), _int_value(), ChangedFile.touches_span(),
+        stable_finding_id().
+    """
     data = _load_json_object(raw_response)
     changed_paths = _index_changed_paths(files)
     required_keys = {
@@ -288,6 +401,22 @@ def _parse_specialist_response(
         note=str(data.get("note", "")),
     )
 def _int_value(value: object) -> int | None:
+    """Parse provider line-number values as integers.
+
+    Purpose:
+        Convert line_start and line_end values from JSON output into ints for
+        span validation.
+    Important parameters:
+        value is any JSON-derived object.
+    Return value:
+        int on successful conversion, otherwise None.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        TypeError and ValueError return None, causing the finding to be skipped.
+    Trace:
+        _parse_specialist_response(), ChangedFile.touches_span().
+    """
     try:
         return int(str(value))
     except (TypeError, ValueError):
@@ -296,7 +425,7 @@ def _int_value(value: object) -> int | None:
 
 def _parse_blocking_recommendation(value: object) -> bool:
     """Parse blocking_recommendation field safely.
-    
+
     Handles JSON booleans, strings ("true"/"false"), and defaults to False.
     """
     if isinstance(value, bool):
@@ -371,6 +500,24 @@ def _missing_prompt_response(*, prompt_name: str, specialist: str, shared: bool)
 
 
 def _load_json_object(raw_response: str) -> dict[str, object]:
+    """Load a JSON object from provider response text.
+
+    Purpose:
+        Parse the provider response directly, or recover the substring between
+        the first `{` and last `}` when extra text surrounds JSON.
+    Important parameters:
+        raw_response is the untrusted provider response string.
+    Return value:
+        Parsed JSON object or a fallback dict with empty findings, empty
+        uncertain_risks, and an invalid-response note.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        JSONDecodeError triggers substring recovery; failed recovery returns the
+        fallback invalid non-JSON response object.
+    Trace:
+        json.loads(), raw_response.find(), raw_response.rfind().
+    """
     try:
         payload = json.loads(raw_response)
         if isinstance(payload, dict):
@@ -395,6 +542,23 @@ def _invalid_specialist_payload(note: str) -> dict[str, object]:
 
 
 def prompt_context_was_truncated(context: ReviewContext, files: tuple[ChangedFile, ...]) -> bool:
+    """Report whether prompt metadata context would be truncated.
+
+    Purpose:
+        Let the coordinator decide whether to add a prompt-context truncation
+        risk for a specialist input.
+    Important parameters:
+        context supplies commit truncation and commits; files supplies changed
+        paths for the specialist.
+    Return value:
+        Boolean _PromptContextBlocks.truncated value.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Uses the same limits as _build_prompt_context_blocks().
+    Trace:
+        _build_prompt_context_blocks(), MAX_PROMPT_FILES, MAX_PROMPT_COMMITS.
+    """
     return _build_prompt_context_blocks(context, files).truncated
 
 
@@ -402,6 +566,25 @@ def _build_prompt_context_blocks(
     context: ReviewContext,
     files: tuple[ChangedFile, ...],
 ) -> _PromptContextBlocks:
+    """Build bounded file-list and commit blocks for specialist prompts.
+
+    Purpose:
+        Convert changed paths and commit subjects into bullet blocks with
+        omission notes when file or commit limits are exceeded.
+    Important parameters:
+        context supplies commits and commit_context_truncated; files supplies
+        ChangedFile.path values.
+    Return value:
+        _PromptContextBlocks with file_list, commit_block, and truncated flag.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Empty file or commit blocks become "- none"; truncated is true when
+        context commit context was truncated, commit count exceeds
+        MAX_PROMPT_COMMITS, or file count exceeds MAX_PROMPT_FILES.
+    Trace:
+        MAX_PROMPT_FILES, MAX_PROMPT_COMMITS, _bullet_block().
+    """
     file_count = len(files)
     file_paths = [changed_file.path for changed_file in files[:MAX_PROMPT_FILES]]
     truncated = context.commit_context_truncated or len(context.commits) > MAX_PROMPT_COMMITS
@@ -440,6 +623,25 @@ def _index_changed_paths(files: tuple[ChangedFile, ...]) -> dict[str, ChangedFil
 
 
 def _lookup_changed_file(path: str, changed_paths: dict[str, ChangedFile]) -> ChangedFile | None:
+    """Match a specialist-reported path to a changed file.
+
+    Purpose:
+        Normalize provider-reported file paths and reconcile direct, old-path,
+        and unambiguous suffix matches to ChangedFile objects.
+    Important parameters:
+        path is a provider-reported file path; changed_paths maps normalized new
+        and old paths to ChangedFile instances.
+    Return value:
+        Matching ChangedFile or None.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Empty normalized paths return None; ambiguous suffix matches return None
+        instead of guessing.
+    Trace:
+        _normalize_specialist_path(), _index_changed_paths(),
+        ChangedFile.old_path.
+    """
     normalized = _normalize_specialist_path(path)
     if not normalized:
         return None
@@ -460,6 +662,23 @@ def _lookup_changed_file(path: str, changed_paths: dict[str, ChangedFile]) -> Ch
 
 
 def _normalize_specialist_path(path: object) -> str:
+    """Normalize a provider-reported path for matching.
+
+    Purpose:
+        Convert path-like provider output into a stable POSIX-style path key.
+    Important parameters:
+        path may be None or any object convertible to str.
+    Return value:
+        Normalized string or "" when no usable path remains.
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        None, empty strings, and "." normalize to ""; leading "./" prefixes are
+        removed; backslashes become slashes; surrounding backticks/quotes are
+        stripped.
+    Trace:
+        PurePosixPath, _lookup_changed_file(), _index_changed_paths().
+    """
     if path is None:
         return ""
     normalized = str(path).strip().strip("`'\"").replace("\\", "/")

--- a/src/blokus/review/static_analyzer.py
+++ b/src/blokus/review/static_analyzer.py
@@ -1,4 +1,13 @@
-"""Static-analysis support for agentic review."""
+"""Diff-aware static-analysis support for the agentic PR review flow.
+
+This module runs deterministic checks over changed executable Python and shell
+files before the agentic review coordinator renders final findings. It invokes
+local tools such as compileall, Ruff, Mypy, bash syntax checks, and ShellCheck
+when they are available, then normalizes changed-line diagnostics into Finding
+objects. It also emits UncertainRisk records for skipped, capped, unavailable,
+or unparsable analysis and adds repository-specific heuristics for sensitive
+paths, dependency metadata, and missing nearby tests.
+"""
 
 from __future__ import annotations
 
@@ -61,12 +70,60 @@ class _ToolParseResult:
 
 
 class StaticAnalyzer:
-    """Run diff-aware static-analysis checks and heuristics."""
+    """Coordinate deterministic static checks and repository heuristics.
+
+    Purpose:
+        Provide the static-analysis layer used by ReviewCoordinator before any
+        provider-backed specialist review runs.
+    Important parameters:
+        config: ReviewConfig stored at construction time; supplies repo_root,
+            command timeout settings, and heuristic path configuration.
+    Return value:
+        Public analysis returns StaticAnalysisReport instances containing
+        normalized Finding and UncertainRisk objects.
+    Side effects:
+        Methods may execute local subprocesses under config.repo_root and may
+        create temporary Mypy response files for oversized command batches.
+    Failure or fallback behavior:
+        Missing tools, capped analysis, command timeouts, and invalid JSON tool
+        output are represented as uncertain risks instead of being treated as a
+        complete static-analysis result.
+    Trace:
+        analyze(), _run_command(), _discover_tool(), _build_mypy_commands(),
+        _heuristic_findings(), StaticAnalysisReport.
+    """
 
     def __init__(self, config: ReviewConfig) -> None:
         self.config = config
 
     def analyze(self, context: ReviewContext) -> StaticAnalysisReport:
+        """Run changed-file static analysis and return a normalized report.
+
+        Purpose:
+            Select changed executable Python and shell files, run bounded local
+            tool checks, parse changed-line diagnostics, add repository
+            heuristics, and compute the static-analysis posture.
+        Important parameters:
+            context: ReviewContext containing changed_files, executable_files,
+                file categories, paths, and changed line spans.
+        Return value:
+            StaticAnalysisReport with findings, uncertain_risks, executed
+            command strings, and a posture of "not_run", "clean",
+            "issues_found", or "unavailable".
+        Side effects:
+            Executes compileall, Ruff, Mypy, bash, and ShellCheck subprocesses
+            when relevant and available; deletes Mypy temporary response files
+            in a finally block.
+        Failure or fallback behavior:
+            Caps compileall at _MAX_COMPILEALL_FILES, skips Ruff and Mypy above
+            _MAX_EXPENSIVE_PYTHON_ANALYSIS_FILES, records missing tools as
+            UncertainRisk entries, and propagates parser uncertainty from JSON
+            tool output.
+        Trace:
+            _build_tool_batches(), _discover_tool(), _run_command(),
+            _parse_compileall(), _parse_ruff(), _parse_mypy(), _parse_bash(),
+            _parse_shellcheck(), _heuristic_findings().
+        """
         python_files = [changed_file for changed_file in context.executable_files if "python" in changed_file.categories]
         shell_files = [changed_file for changed_file in context.executable_files if "shell" in changed_file.categories]
 
@@ -305,6 +362,29 @@ class StaticAnalyzer:
         )
 
     def _parse_ruff(self, context: ReviewContext, tool_run: ToolRun) -> _ToolParseResult:
+        """Convert Ruff JSON diagnostics into changed-line findings.
+
+        Purpose:
+            Parse stdout from `ruff check --output-format json` and emit
+            findings only for diagnostics whose file and start line match the
+            review diff.
+        Important parameters:
+            context: ReviewContext used to verify changed files and line spans.
+            tool_run: ToolRun containing Ruff stdout, stderr, return code, and
+                command text.
+        Return value:
+            _ToolParseResult containing findings plus any JSON parsing
+            uncertainty.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Empty stdout returns no findings; oversized, invalid, or
+            wrong-shaped JSON returns an UncertainRisk with unavailable=True;
+            malformed entries are skipped.
+        Trace:
+            _load_json_output(), _normalize_tool_path(), _positive_int(),
+            _lookup_changed_file(), stable_finding_id().
+        """
         if not tool_run.stdout.strip():
             return _ToolParseResult()
 
@@ -355,6 +435,26 @@ class StaticAnalyzer:
         return _ToolParseResult(findings=tuple(findings))
 
     def _parse_mypy(self, context: ReviewContext, tool_run: ToolRun) -> list[Finding]:
+        """Parse Mypy text output into changed-line type findings.
+
+        Purpose:
+            Read Mypy stdout lines matching _MYPY_RE and report only `error`
+            diagnostics that map to changed lines.
+        Important parameters:
+            context: ReviewContext used for changed-file and changed-line
+                filtering.
+            tool_run: ToolRun containing Mypy stdout.
+        Return value:
+            High-severity Finding objects for changed-line Mypy errors.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Non-matching lines, `note` diagnostics, unnormalizable paths, and
+            diagnostics outside changed lines are ignored.
+        Trace:
+            _MYPY_RE, _normalize_tool_path(), _lookup_changed_file(),
+            stable_finding_id().
+        """
         findings: list[Finding] = []
         for raw_line in tool_run.stdout.splitlines():
             match = _MYPY_RE.match(raw_line.strip())
@@ -389,6 +489,27 @@ class StaticAnalyzer:
         return findings
 
     def _parse_compileall(self, context: ReviewContext, tool_run: ToolRun) -> list[Finding]:
+        """Parse compileall failures into Python compile-error findings.
+
+        Purpose:
+            Use _COMPILEALL_RE over combined stdout and stderr from
+            `python -m compileall` to identify changed Python files that failed
+            to compile.
+        Important parameters:
+            context: ReviewContext used to restrict findings to changed lines.
+            tool_run: ToolRun produced by the compileall command.
+        Return value:
+            High-severity Python compile-error findings.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Return code 0 returns no findings; unmatched output,
+            unnormalizable paths, and diagnostics outside changed lines are
+            ignored.
+        Trace:
+            _COMPILEALL_RE, _normalize_tool_path(), _lookup_changed_file(),
+            stable_finding_id().
+        """
         if tool_run.returncode == 0:
             return []
         findings: list[Finding] = []
@@ -422,6 +543,26 @@ class StaticAnalyzer:
         return findings
 
     def _parse_bash(self, shell_files: list[ChangedFile], tool_run: ToolRun) -> list[Finding]:
+        """Parse bash syntax-check stderr for changed shell-script lines.
+
+        Purpose:
+            Convert `bash -n` syntax errors into findings for changed shell
+            files.
+        Important parameters:
+            shell_files: Changed shell files selected by analyze().
+            tool_run: ToolRun produced by the bash syntax-check command.
+        Return value:
+            High-severity shell syntax findings.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Return code 0 returns no findings; stderr lines that do not match
+            _BASH_RE, paths outside shell_files, invalid line numbers, and
+            unchanged lines are ignored.
+        Trace:
+            _BASH_RE, _normalize_tool_path(), _positive_int(),
+            ChangedFile.touches_line(), stable_finding_id().
+        """
         if tool_run.returncode == 0:
             return []
         findings: list[Finding] = []
@@ -457,6 +598,28 @@ class StaticAnalyzer:
         return findings
 
     def _parse_shellcheck(self, shell_files: list[ChangedFile], tool_run: ToolRun) -> _ToolParseResult:
+        """Convert ShellCheck JSON comments into changed-line findings.
+
+        Purpose:
+            Parse stdout from `shellcheck -f json1` and report comments that
+            apply to changed shell-script lines.
+        Important parameters:
+            shell_files: Changed shell files selected by analyze().
+            tool_run: ToolRun containing ShellCheck stdout, stderr, return code,
+                and command text.
+        Return value:
+            _ToolParseResult containing findings plus any JSON parsing
+            uncertainty.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Empty stdout returns no result; oversized, invalid, or wrong-shaped
+            JSON returns an UncertainRisk with unavailable=True; missing or
+            non-list `comments` returns no findings.
+        Trace:
+            _load_json_output(), _normalize_tool_path(), _positive_int(),
+            ChangedFile.touches_line(), stable_finding_id().
+        """
         if not tool_run.stdout.strip():
             return _ToolParseResult()
         findings: list[Finding] = []
@@ -503,6 +666,26 @@ class StaticAnalyzer:
         return _ToolParseResult(findings=tuple(findings))
 
     def _heuristic_findings(self, context: ReviewContext) -> list[Finding]:
+        """Add repository-specific findings that do not come from tools.
+
+        Purpose:
+            Flag path-based review risks for schemas, fixtures, CLI entrypoints,
+            serialization-sensitive files, missing test updates, and
+            workflow-sensitive paths.
+        Important parameters:
+            context: ReviewContext containing all changed file paths.
+        Return value:
+            Normalized Finding objects with source="static-analyzer".
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            Heuristics emit findings only when their path and coverage
+            conditions match; the generic missing-tests finding is skipped if a
+            more specific heuristic finding already exists.
+        Trace:
+            config.heuristics, tests_missing(), is_sensitive_path(),
+            stable_finding_id().
+        """
         findings: list[Finding] = []
         changed_paths = {changed_file.path for changed_file in context.changed_files}
         test_paths = {path for path in changed_paths if path.startswith("tests/")}
@@ -635,6 +818,24 @@ class StaticAnalyzer:
         return findings
 
     def _heuristic_uncertain_risks(self, context: ReviewContext) -> list[UncertainRisk]:
+        """Record uncertainty for dependency metadata changes.
+
+        Purpose:
+            Note that dependency-related files changed when configured
+            dependency paths appear in the diff.
+        Important parameters:
+            context: ReviewContext containing changed file paths.
+        Return value:
+            A one-item UncertainRisk list when dependency paths changed;
+            otherwise an empty list.
+        Side effects:
+            None.
+        Failure or fallback behavior:
+            No dependency-path overlap returns no risk. The function does not
+            inspect dependency contents or verify supply-chain intent.
+        Trace:
+            config.heuristics.dependency_files, UncertainRisk.
+        """
         changed_paths = {changed_file.path for changed_file in context.changed_files}
         dependency_paths = changed_paths & set(self.config.heuristics.dependency_files)
         if not dependency_paths:
@@ -657,6 +858,26 @@ class StaticAnalyzer:
         return None
 
     def _run_command(self, args: list[str]) -> ToolRun:
+        """Execute one static-analysis subprocess and capture its streams.
+
+        Purpose:
+            Run a local command in the repository root with captured text output
+            and the configured timeout.
+        Important parameters:
+            args: Command argument list passed directly to subprocess.run().
+        Return value:
+            ToolRun containing the joined command string, return code, stdout,
+            and stderr.
+        Side effects:
+            Executes a local subprocess with cwd=config.repo_root.
+        Failure or fallback behavior:
+            subprocess.TimeoutExpired is converted to returncode 124 with any
+            captured partial streams coerced to text and a timeout message
+            appended to stderr.
+        Trace:
+            subprocess.run(), config.repo_root, config.provider.timeout_seconds,
+            _coerce_stream_text(), ToolRun.
+        """
         with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
             try:
                 completed = subprocess.run(
@@ -715,6 +936,28 @@ class StaticAnalyzer:
         mypy_path: str,
         python_files: list[ChangedFile],
     ) -> tuple[list[list[str]], list[Path]]:
+        """Build Mypy command arguments and cleanup paths.
+
+        Purpose:
+            Create Mypy invocations using pyproject.toml and stable output
+            flags, falling back to one response-file invocation when direct
+            batching would split the file list.
+        Important parameters:
+            mypy_path: Resolved path to the Mypy executable.
+            python_files: Changed Python files selected by analyze().
+        Return value:
+            A tuple of command argument lists and temporary Paths that callers
+            must delete after command execution.
+        Side effects:
+            May create a `.agentic-mypy-*.txt` temporary response file under
+            config.repo_root.
+        Failure or fallback behavior:
+            If response-file creation or writing fails, the temporary file is
+            unlinked before the exception is re-raised.
+        Trace:
+            _build_tool_batches(), _safe_tool_path(),
+            tempfile.NamedTemporaryFile(), analyze() finally cleanup.
+        """
         prefix_args = [
             mypy_path,
             "--config-file",
@@ -820,6 +1063,26 @@ def _build_tool_batches(
     *,
     supports_option_terminator: bool = False,
 ) -> list[list[str]]:
+    """Split changed-file tool invocations into bounded argument batches.
+
+    Purpose:
+        Build command argument lists that combine a tool prefix with changed-file
+        paths while respecting file-count and argument-length limits.
+    Important parameters:
+        prefix_args: Command prefix placed before file paths.
+        changed_files: Changed files whose paths should be passed to the tool.
+        supports_option_terminator: When true, inserts `--` before paths for
+            tools that support option termination.
+    Return value:
+        A list of command argument lists; empty changed_files returns [].
+    Side effects:
+        None.
+    Failure or fallback behavior:
+        Paths are normalized through _safe_tool_path(); batches split at
+        _MAX_TOOL_BATCH_FILES or _MAX_TOOL_BATCH_CHARS.
+    Trace:
+        _MAX_TOOL_BATCH_FILES, _MAX_TOOL_BATCH_CHARS, _safe_tool_path().
+    """
     if not changed_files:
         return []
 


### PR DESCRIPTION
## Summary

Adds maintainer-focused Python docstrings across the agentic review workflow and GitHub helper scripts. The docstrings document purpose, parameters, return values, side effects, fallback behavior, and concrete trace links for future maintainers.

This PR is documentation-only. The branch was created from the refreshed `origin/main`, and only these files are included:

- `scripts/github/agentic_code_review.py`
- `scripts/github/repair_loop.py`
- `src/blokus/review/coordinator.py`
- `src/blokus/review/diff.py`
- `src/blokus/review/provider.py`
- `src/blokus/review/specialists.py`
- `src/blokus/review/static_analyzer.py`

Two originally requested docstring targets were not present on the refreshed base branch (`_render_patch_block` in `diff.py` and `_dict_list` in `specialists.py`), so no docstrings were added for missing symbols.

## Validation

- `python -m compileall scripts/github/agentic_code_review.py scripts/github/repair_loop.py src/blokus/review/static_analyzer.py src/blokus/review/diff.py src/blokus/review/coordinator.py src/blokus/review/specialists.py src/blokus/review/provider.py`
- `git diff --check`
- AST comparison against `HEAD` after stripping module/class/function docstrings
- `env PYTHONPATH=src python -m pytest tests/test_agentic_review.py -k "static_analyzer or build_review_context or load_changed_files or parse_line_spans or performance_review or resolve_refs or specialist_response or specialist_runner or prompt_context or coordinator"`
- `env PYTHONPATH=src python -m pytest tests/test_agentic_code_review_cli.py -k "not posts_same_repo_comment"`
- `env PYTHONPATH=src python -m pytest tests/test_automation.py::AutomationTests::test_repair_policy_blocks_sensitive_paths tests/test_automation.py::AutomationTests::test_repair_policy_allows_safe_agent_branch tests/test_automation.py::AutomationTests::test_state_marker_round_trips`