### PR TITLE
[codex] Reject readded played pieces on load

### DIFF
--- a/src/blokus/models.py
+++ b/src/blokus/models.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from blokus.config import get_mode_config, player_for_symbol, symbol_for_player
 from blokus.pieces import PIECE_IDS
@@ -237,7 +237,28 @@ class GameState:
             for player in players
         }
 
-        history = [Move.from_dict(item) for item in data.get("history", [])]
+        history: list[Move] = []
+        played_pieces: dict[str, set[str]] = {player: set() for player in players}
+        for item in cast(list[Mapping[str, object]], data.get("history", [])):
+            move = Move.from_dict(item)
+            if move.player not in players:
+                raise ValueError(f"History references unknown player '{move.player}'.")
+            if move.piece not in PIECE_IDS:
+                raise ValueError(f"History references unknown piece '{move.piece}'.")
+            if move.piece in played_pieces[move.player]:
+                raise ValueError(
+                    f"Piece '{move.piece}' already appears in history for player '{move.player}'."
+                )
+            played_pieces[move.player].add(move.piece)
+            history.append(move)
+        for player, pieces in played_pieces.items():
+            readded_pieces = pieces & remaining_pieces[player]
+            if readded_pieces:
+                piece_list = ", ".join(sorted(readded_pieces, key=lambda piece_id: PIECE_IDS.index(piece_id)))
+                raise ValueError(
+                    f"Piece '{piece_list}' already appears in history for player '{player}' "
+                    "and cannot remain available."
+                )
 
         controller_source = data.get("controller_types", {})
         controllers = {

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -137,6 +137,41 @@ class SerializationTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "contain duplicates"):
             GameState.from_dict(payload)
 
+    def test_load_rejects_played_piece_readded_to_remaining_pieces(self) -> None:
+        state = apply_move(new_game(), Move("blue", "I1", 0, 0))
+        payload = state.to_dict()
+        remaining_pieces = cast(dict[str, list[str]], payload["remaining_pieces"])
+        remaining_pieces["blue"].append("I1")
+
+        with self.assertRaisesRegex(ValueError, "already appears in history"):
+            GameState.from_dict(payload)
+
+    def test_history_unknown_player_is_rejected(self) -> None:
+        payload = self.load_initial_payload()
+        payload["history"] = [Move("orange", "I1", 0, 0).to_dict()]
+
+        with self.assertRaisesRegex(ValueError, "unknown player"):
+            GameState.from_dict(payload)
+
+    def test_history_unknown_piece_is_rejected(self) -> None:
+        payload = self.load_initial_payload()
+        payload["history"] = [Move("blue", "BAD", 0, 0).to_dict()]
+
+        with self.assertRaisesRegex(ValueError, "unknown piece"):
+            GameState.from_dict(payload)
+
+    def test_history_duplicate_piece_for_player_is_rejected(self) -> None:
+        payload = self.load_initial_payload()
+        remaining_pieces = cast(dict[str, list[str]], payload["remaining_pieces"])
+        remaining_pieces["blue"].remove("I1")
+        payload["history"] = [
+            Move("blue", "I1", 0, 0).to_dict(),
+            Move("blue", "I1", 1, 1).to_dict(),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "already appears in history"):
+            GameState.from_dict(payload)
+
     def test_agentic_review_payload_matches_schema_shape(self) -> None:
         schema_path = REPO_ROOT / "schemas" / "agentic_review_output.schema.json"
         schema = json.loads(schema_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Reject deserialized game states where a move history piece is still listed as available in `remaining_pieces`.
- Validate history entries for unknown players, unknown pieces, and duplicate piece use by the same player while loading.
- Add a focused regression test for re-adding blue's played `I1` after serialization.

## Root Cause
`GameState.from_dict` rebuilt `history` and `remaining_pieces` independently. A tampered serialized state could put a played piece back into a player's remaining rack, allowing later move validation and legal move generation to reuse that piece.

## Validation
- `PYTHONPATH=src python -m unittest tests.test_serialization -v`
- `PYTHONPATH=src python -m unittest tests.test_engine -v`
- `PYTHONPATH=src python -m unittest tests.test_serialization tests.test_engine tests.test_cli tests.test_ai -v`