### PR TITLE
[codex] Harden review agent normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .pytest_cache/
 .cache/
+.agentic-mypy-*.txt
 *.pyc
 *.pyo
 *.pyd

--- a/src/blokus/review/config.py
+++ b/src/blokus/review/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -169,11 +168,7 @@ def _normalized_env_value(name: str) -> str:
 
 
 def _coerce_str_list(value: object, field_name: str, config_path: Path) -> tuple[str, ...]:
-    """Coerce a value to a tuple of strings.
-
-    Handles lists of strings (normal case) and single strings (coerced to single-item list).
-    Raises ValueError for invalid types.
-    """
+    """Coerce a list value to a tuple of non-empty strings."""
     if isinstance(value, list):
         coerced: list[str] = []
         for index, item in enumerate(value):
@@ -182,18 +177,20 @@ def _coerce_str_list(value: object, field_name: str, config_path: Path) -> tuple
                     f"Config field `{field_name}` item at index {index} must be a string, "
                     f"got {type(item).__name__}."
                 )
-            coerced.append(item)
+            stripped = item.strip()
+            if not stripped:
+                raise ValueError(
+                    f"Config field `{field_name}` item at index {index} must not be empty."
+                )
+            coerced.append(stripped)
         return tuple(coerced)
     if isinstance(value, str):
-        warnings.warn(
-            f"Config field `{field_name}` should be a list, not a string. "
-            f"Coercing '{value}' to ['{value}'].",
-            UserWarning,
-            stacklevel=3,
+        raise ValueError(
+            f"Config field `{field_name}` must be a list, got a string. "
+            f"Wrap the value in brackets: [{value!r}]."
         )
-        return (value,)
     raise ValueError(
-        f"Config field `{field_name}` must be a list of strings or a single string, "
+        f"Config field `{field_name}` must be a list of strings, "
         f"got {type(value).__name__}."
     )
 

--- a/src/blokus/review/specialists.py
+++ b/src/blokus/review/specialists.py
@@ -318,18 +318,24 @@ def _parse_blocking_recommendation(value: object) -> bool:
 
 def _normalize_severity(value: object) -> str:
     normalized = str(value).strip().lower()
-    return {
+    mapped = {
         "medium": "moderate",
         "med": "moderate",
     }.get(normalized, normalized)
+    if mapped not in {"critical", "high", "moderate", "low"}:
+        return "moderate"
+    return mapped
 
 
 def _normalize_confidence(value: object) -> str:
     normalized = str(value).strip().lower()
-    return {
+    mapped = {
         "moderate": "medium",
         "med": "medium",
     }.get(normalized, normalized)
+    if mapped not in {"high", "medium", "low"}:
+        return "medium"
+    return mapped
 
 
 def _normalize_category(value: object) -> str:

--- a/tests/test_agentic_review.py
+++ b/tests/test_agentic_review.py
@@ -18,7 +18,15 @@ import blokus.review.coordinator as review_coordinator
 import blokus.review.diff as review_diff
 import blokus.review.renderer as review_renderer
 import blokus.review.static_analyzer as review_static_analyzer
-from blokus.review.config import MAX_PROVIDER_RETRIES, HeuristicConfig, PerformanceConfig, ProviderConfig, ReviewConfig, load_review_config
+from blokus.review.config import (
+    MAX_PROVIDER_RETRIES,
+    HeuristicConfig,
+    PerformanceConfig,
+    ProviderConfig,
+    ReviewConfig,
+    _coerce_str_list,
+    load_review_config,
+)
 from blokus.review.coordinator import ReviewCoordinator, ReviewRun
 from blokus.review.diff import build_review_context, should_run_performance_review
 from blokus.review.provider import OpenRouterClient, ProviderUnavailable
@@ -877,6 +885,36 @@ class AgenticReviewTests(unittest.TestCase):
         self.assertEqual(response.findings[0].severity, "high")
         self.assertEqual(response.findings[0].confidence, "medium")
         self.assertEqual(response.findings[0].category, "static-analysis")
+
+    def test_specialist_response_defaults_unknown_severity_and_confidence(self) -> None:
+        files = (_changed_file("src/blokus/engine.py", line_start=20, line_end=20),)
+        response = _parse_specialist_response(
+            json.dumps(
+                {
+                    "findings": [
+                        {
+                            "title": "Non-canonical enums",
+                            "severity": "severe",
+                            "confidence": "very_high",
+                            "category": "correctness",
+                            "file": "src/blokus/engine.py",
+                            "line_start": 20,
+                            "line_end": 20,
+                            "evidence": "Changed logic mishandles empty input.",
+                            "impact": "Can reject legal moves.",
+                            "suggested_action": "Add the missing empty-input guard.",
+                            "blocking_recommendation": True,
+                        }
+                    ]
+                }
+            ),
+            "correctness",
+            files,
+        )
+
+        self.assertEqual(len(response.findings), 1)
+        self.assertEqual(response.findings[0].severity, "moderate")
+        self.assertEqual(response.findings[0].confidence, "medium")
 
     def test_specialist_response_parses_uncertain_risks_and_note(self) -> None:
         files = (_changed_file("src/blokus/engine.py", line_start=20, line_end=20),)
@@ -3638,15 +3676,14 @@ class AgenticReviewTests(unittest.TestCase):
         self.assertLessEqual(len(fake_runner.captured_diff), review_coordinator.MAX_RENDERED_DIFF_CHARS)
         self.assertIn("truncated for scale", fake_runner.captured_diff)
 
-    def test_config_coerces_string_to_list(self) -> None:
-        """Config should coerce string values to single-item lists."""
-        import warnings
+    def test_config_rejects_string_list_values(self) -> None:
+        """Config should require list syntax for string-list fields."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
             (repo_root / ".github").mkdir()
             config_text = """
 max_findings = 5
-excluded_globs = "*.md"
+excluded_globs = ["*.md"]
 blocking_severities = ["critical", "high"]
 prompt_dir = ".github/prompts"
 spec_path = "docs/spec.md"
@@ -3674,18 +3711,16 @@ default = "default-model"
 """
             (repo_root / ".github" / "agentic-review.toml").write_text(config_text, encoding="utf-8")
 
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
-                config = load_review_config(repo_root=repo_root)
+            with self.assertRaisesRegex(ValueError, "performance.path_markers.*must be a list, got a string"):
+                load_review_config(repo_root=repo_root)
 
-                # Check that string was coerced to tuple
-                self.assertEqual(config.excluded_globs, ("*.md",))
-                self.assertEqual(config.performance.path_markers, ("src/engine.py",))
+    def test_coerce_str_list_rejects_empty_items(self) -> None:
+        with self.assertRaisesRegex(ValueError, "path_markers.*index 1.*must not be empty"):
+            _coerce_str_list(["src/blokus/engine.py", "", "tests/"], "path_markers", REPO_ROOT)
 
-                # Check that warning was issued
-                self.assertTrue(
-                    any("excluded_globs" in str(warning.message) for warning in w)
-                )
+    def test_coerce_str_list_rejects_non_string_items(self) -> None:
+        with self.assertRaisesRegex(ValueError, "path_markers.*index 1.*must be a string"):
+            _coerce_str_list(["src/blokus/engine.py", 7], "path_markers", REPO_ROOT)
 
     def test_config_rejects_invalid_types(self) -> None:
         """Config should reject non-string, non-list values."""


### PR DESCRIPTION
## Summary

- Canonicalize unknown specialist severity/confidence values to safe defaults so LLM findings are not silently dropped by coordinator validation.
- Make review config string-list fields strict: reject scalar strings, non-string items, and empty entries instead of accepting silent misconfiguration.
- Ignore orphaned `.agentic-mypy-*.txt` response files defensively.

## Root Cause

Specialist enum normalization only handled a few aliases and let unknown values pass through unchanged. The coordinator later rejected those findings as invalid. Config list coercion also accepted scalar strings and empty entries, letting invalid markers propagate into review behavior.

## Validation

- `env PYTHONPATH=src python -m pytest tests/test_agentic_review.py -k "specialist_response_defaults_unknown_severity_and_confidence or specialist_response_normalizes_common_enum_variants or config_rejects_string_list_values or coerce_str_list_rejects"`
- `python -m compileall -q src/blokus/review/specialists.py src/blokus/review/config.py tests/test_agentic_review.py`
- `git diff --check -- .gitignore src/blokus/review/config.py src/blokus/review/specialists.py tests/test_agentic_review.py`