### PR TITLE
[codex] Update Duo CLI test expectation

### DIFF
--- a/tests/test_duo_cross_layer_integration.py
+++ b/tests/test_duo_cross_layer_integration.py
@@ -254,7 +254,7 @@ class DuoCrossLayerIntegrationTests(unittest.TestCase):
             )
             self.assertEqual(rejected.returncode, 1)
             self.assertIn(
-                "Opening move for red must cover start corner (9, 9).",
+                "First move coordinates must be the start corner (9, 9), got (8, 8).",
                 rejected.stdout,
             )
             self.assertEqual(after_path.read_text(encoding="utf-8"), after_text)


### PR DESCRIPTION
## Summary
- Update the Duo cross-layer CLI test to expect the current first-move coordinate validation message.

## Root cause
The CLI now rejects invalid first-move human coordinates before the move reaches engine validation, so the emitted error is `First move coordinates must be the start corner (9, 9), got (8, 8).` instead of the older engine-level opening-move message.

## Validation
- `./scripts/test.sh` in `/Users/anatolelobenko/Documents/GitHub/Blokus_GenAI-latest`
- Result: `388 passed, 3 skipped`